### PR TITLE
feat(core): X-Wing hybrid DEK (X25519 + ML-KEM-768)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha2",
+ "sha3 0.10.9",
  "sharks",
  "tar",
  "tempfile",
@@ -1195,6 +1196,7 @@ dependencies = [
  "tzf-rs",
  "uuid",
  "walkdir",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -3177,6 +3179,15 @@ dependencies = [
 
 [[package]]
 name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
@@ -3429,7 +3440,7 @@ dependencies = [
  "module-lattice",
  "pkcs8 0.11.0",
  "rand_core 0.10.1",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -5695,12 +5706,22 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -5710,7 +5731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.0",
  "sponge-cursor",
 ]
 
@@ -7907,6 +7928,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -12,7 +12,8 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
 - **Canonical CBOR** (RFC 8949 §4.2) — the byte-identity contract for every signature/hash.
 - **Crypto primitives** — SHA-256 (streaming), HKDF-SHA512, Argon2id, AES-256-GCM (STREAM +
   standalone metadata-blob), **hybrid Ed25519 + ML-DSA-65** signatures (both halves required),
-  **ML-KEM-768** DEK.
+  **X-Wing (X25519 + ML-KEM-768)** hybrid DEK (known-answer-validated against
+  `draft-connolly-cfrg-xwing-kem`).
 - **Key hierarchy** — master key, default-album-id derivation, AMKs + per-file/blob keys,
   software keystore (account ↔ encrypted `AccountFile`), signed device directory.
 - **Encryption** — STREAM asset encryption with independent ranged-chunk decryption;
@@ -41,11 +42,6 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
 - **Consequence:** albums are **single-epoch** in the offline core. Epoch rotation,
   membership add/remove, the `Welcome`/history-delivery flow, and the album upgrade ceremony
   are deferred with OpenMLS.
-
-### X-Wing hybrid DEK
-- `crypto::keys::kem` implements the post-quantum **ML-KEM-768** half (full encapsulate/
-  decapsulate round-trip). The X25519 classical half and the X-Wing combiner land with
-  OpenMLS (the seam is byte-string `encapsulate`/`decapsulate`, combiner-agnostic).
 
 ### Hardware-bound key storage
 - Device keys are kept in a **software keystore** (private keys sealed under the

--- a/capsule-core/Cargo.toml
+++ b/capsule-core/Cargo.toml
@@ -29,10 +29,12 @@ aes-gcm = { version = "0.10", features = ["aes"] }
 aead = { version = "0.5", features = ["stream", "alloc"] }
 hkdf = "0.12"
 hmac = "0.12"
+sha3 = "0.10"            # SHA3-256 combiner + SHAKE256 seed expansion for the X-Wing KEM
 argon2 = { workspace = true }
 ed25519-dalek = "2"
 ml-dsa = "0.1"            # RustCrypto FIPS-204 (ML-DSA-65) — the PQ signature half
-ml-kem = "0.3"           # RustCrypto FIPS-203 (ML-KEM-768) — KEM for the device encryption key
+ml-kem = "0.3"           # RustCrypto FIPS-203 (ML-KEM-768) — PQ half of the X-Wing device KEM
+x25519-dalek = "2"       # RustCrypto X25519 — classical half of the X-Wing device KEM
 getrandom = "0.3"        # OS CSPRNG for keys, salts, nonce prefixes
 tar = "0.4"              # deterministic uncompressed POSIX tar backup container
 sharks = "0.5"           # Shamir secret sharing (opt-in 2-of-3 recovery)

--- a/capsule-core/src/crypto/keys/kem.rs
+++ b/capsule-core/src/crypto/keys/kem.rs
@@ -1,33 +1,55 @@
-//! The Device Encryption Key (DEK) — an ML-KEM-768 KEM keypair.
+//! The Device Encryption Key (DEK) — an **X-Wing** hybrid KEM keypair (X25519 + ML-KEM-768).
 //!
 //! The DEK is the device's key-encapsulation key: a sender encapsulates a shared secret
 //! to the device's public key, and the device decapsulates it with its private key. In
 //! Capsule it carries key wraps to a device and underlies MLS HPKE
 //! (SSoT: [Cryptography — Keys § Device Keys], [Primitives § KEM]).
 //!
-//! Keys are deterministic from a 64-byte seed, so the DEK persists and restores verbatim.
+//! This is the hybrid the design's `crypto_suite_id = 0x0001` declares: **X-Wing**
+//! (`draft-connolly-cfrg-xwing-kem`), combining the post-quantum **ML-KEM-768** half with the
+//! classical **X25519** half so neither being broken alone compromises the shared secret. Both
+//! halves are bound into a single 32-byte secret by the X-Wing combiner
+//! `SHA3-256(ss_M ‖ ss_X ‖ ct_X ‖ pk_X ‖ XWingLabel)`.
 //!
-//! **Deferred:** the design's DEK is the *hybrid* X-Wing (X25519 + ML-KEM-768); the
-//! X25519 half and the X-Wing combiner land with the OpenMLS integration (see
-//! `DEFERRED.md`). This module implements the post-quantum ML-KEM-768 half, which is the
-//! part exercised offline. The seam (`encapsulate`/`decapsulate` over byte strings) is
-//! combiner-agnostic, so swapping in X-Wing later does not change callers.
+//! Keys are deterministic from a 32-byte seed (X-Wing's secret key), so the DEK persists and
+//! restores verbatim. The seam (`encapsulate`/`decapsulate` over byte strings) is unchanged
+//! from the earlier ML-KEM-only stand-in, so callers are unaffected by the upgrade.
 //!
 //! [Cryptography — Keys § Device Keys]: https://docs/design/cryptography/keys/#device-keys
 //! [Primitives § KEM]: https://docs/design/cryptography/primitives/#kem
 
 use ml_kem::kem::Decapsulate;
 use ml_kem::{B32, DecapsulationKey, KeyExport, MlKem768, Seed};
+use sha3::digest::{ExtendableOutput, Update, XofReader};
+use sha3::{Digest, Sha3_256, Shake256};
+use x25519_dalek::{X25519_BASEPOINT_BYTES, x25519};
 
 use crate::crypto::{CryptoError, rng};
 
-/// Length of the ML-KEM-768 keypair seed (d ‖ z).
-pub const DEK_SEED_LEN: usize = 64;
+/// Length of the X-Wing secret-key seed. SHAKE256-expanded to 96 bytes: the ML-KEM-768 seed
+/// `d ‖ z` (64) and the X25519 secret scalar (32).
+pub const DEK_SEED_LEN: usize = 32;
 
-/// A device encryption keypair (ML-KEM-768). Holds the private decapsulation key; the
-/// public encapsulation key is reachable from it.
+/// X-Wing public-key length: `pk_M (1184) ‖ pk_X (32)`.
+pub const DEK_PUBLIC_LEN: usize = 1184 + 32;
+/// X-Wing ciphertext length: `ct_M (1088) ‖ ct_X (32)`.
+pub const DEK_CIPHERTEXT_LEN: usize = 1088 + 32;
+/// Length of the X-Wing encapsulation seed: ML-KEM coins `m` (32) and the X25519 ephemeral (32).
+const ESEED_LEN: usize = 64;
+const MLKEM_CT_LEN: usize = 1088;
+
+/// The X-Wing combiner label: the 6-byte ASCII art `\.//^\` (`5c2e2f2f5e5c`).
+const XWING_LABEL: [u8; 6] = [0x5c, 0x2e, 0x2f, 0x2f, 0x5e, 0x5c];
+
+/// A device encryption keypair (X-Wing = X25519 + ML-KEM-768). Holds both private halves; the
+/// public encapsulation key is derived on demand.
 pub struct DekKeypair {
+    /// The 32-byte X-Wing secret-key seed (the value sealed in the keystore).
+    seed: [u8; DEK_SEED_LEN],
+    /// ML-KEM-768 decapsulation key, derived from the seed.
     dk: DecapsulationKey<MlKem768>,
+    /// X25519 secret scalar, derived from the seed.
+    sk_x: [u8; 32],
 }
 
 fn shared_to_32(bytes: &[u8]) -> [u8; 32] {
@@ -36,53 +58,108 @@ fn shared_to_32(bytes: &[u8]) -> [u8; 32] {
     out
 }
 
+/// The X-Wing combiner: bind both shared secrets, the X25519 ciphertext, and the recipient's
+/// static X25519 public key under SHA3-256 with the domain-separating label.
+fn combiner(ss_m: &[u8], ss_x: &[u8; 32], ct_x: &[u8; 32], pk_x: &[u8; 32]) -> [u8; 32] {
+    let mut h = Sha3_256::new();
+    Digest::update(&mut h, ss_m);
+    Digest::update(&mut h, ss_x);
+    Digest::update(&mut h, ct_x);
+    Digest::update(&mut h, pk_x);
+    Digest::update(&mut h, XWING_LABEL);
+    shared_to_32(&h.finalize())
+}
+
 impl DekKeypair {
     /// Generate a fresh DEK from the OS CSPRNG.
     pub fn generate() -> Self {
         Self::from_seed(&rng::random_array::<DEK_SEED_LEN>())
     }
 
-    /// Reconstruct deterministically from a 64-byte seed.
+    /// Reconstruct deterministically from the 32-byte X-Wing seed (`expandDecapsulationKey`).
     pub fn from_seed(seed: &[u8; DEK_SEED_LEN]) -> Self {
-        let s = Seed::try_from(&seed[..]).expect("64-byte ML-KEM seed");
+        // expanded = SHAKE256(seed, 96): [0:64] = ML-KEM d‖z, [64:96] = X25519 scalar.
+        let mut xof = Shake256::default();
+        xof.update(seed);
+        let mut reader = xof.finalize_xof();
+        let mut expanded = [0u8; 96];
+        reader.read(&mut expanded);
+
+        let s = Seed::try_from(&expanded[..64]).expect("64-byte ML-KEM seed");
+        let dk = DecapsulationKey::<MlKem768>::from_seed(s);
+        let sk_x = shared_to_32(&expanded[64..96]);
         Self {
-            dk: DecapsulationKey::<MlKem768>::from_seed(s),
+            seed: *seed,
+            dk,
+            sk_x,
         }
     }
 
-    /// Export the 64-byte seed for sealed storage in the keystore.
+    /// Export the 32-byte X-Wing seed for sealed storage in the keystore.
     pub fn to_seed_bytes(&self) -> [u8; DEK_SEED_LEN] {
-        let seed = self
-            .dk
-            .to_seed()
-            .expect("a seed-derived DEK always retains its seed");
-        let mut out = [0u8; DEK_SEED_LEN];
-        out.copy_from_slice(seed.as_slice());
+        self.seed
+    }
+
+    /// This device's static X25519 public key (`pk_X = X25519(sk_X, base)`).
+    fn pk_x(&self) -> [u8; 32] {
+        x25519(self.sk_x, X25519_BASEPOINT_BYTES)
+    }
+
+    /// The X-Wing public encapsulation-key bytes `pk_M ‖ pk_X` (for the device directory).
+    pub fn public_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(DEK_PUBLIC_LEN);
+        out.extend_from_slice(self.dk.encapsulation_key().to_bytes().as_slice());
+        out.extend_from_slice(&self.pk_x());
         out
     }
 
-    /// The public encapsulation-key bytes (for publishing in the device directory).
-    pub fn public_bytes(&self) -> Vec<u8> {
-        self.dk.encapsulation_key().to_bytes().to_vec()
-    }
-
     /// Encapsulate a fresh shared secret to this keypair's own public key, returning the
-    /// ciphertext and the 32-byte shared secret (the sender's side of a round trip).
+    /// X-Wing ciphertext `ct_M ‖ ct_X` and the 32-byte combined shared secret (sender side).
     pub fn encapsulate_to_self(&self) -> (Vec<u8>, [u8; 32]) {
-        // `encapsulate_deterministic` takes the encapsulation randomness explicitly; we
-        // draw it fresh from the OS CSPRNG, so this is a randomized encapsulation.
-        let m = B32::try_from(&rng::random_array::<32>()[..]).expect("32-byte m");
-        let (ct, ss) = self.dk.encapsulation_key().encapsulate_deterministic(&m);
-        (ct.as_slice().to_vec(), shared_to_32(ss.as_slice()))
+        self.encapsulate_to_self_derand(&rng::random_array::<ESEED_LEN>())
     }
 
-    /// Decapsulate a ciphertext, recovering the 32-byte shared secret (the receiver side).
+    /// Derandomized encapsulation to self (the X-Wing `EncapsDerand` with explicit `eseed`):
+    /// `eseed[0:32]` is the ML-KEM coin `m`, `eseed[32:64]` the X25519 ephemeral scalar.
+    /// Exposed for known-answer testing; the public path draws `eseed` from the OS CSPRNG.
+    fn encapsulate_to_self_derand(&self, eseed: &[u8; ESEED_LEN]) -> (Vec<u8>, [u8; 32]) {
+        let pk_x = self.pk_x();
+
+        // ML-KEM-768 half: derandomized encapsulation to our own encapsulation key.
+        let m = B32::try_from(&eseed[..32]).expect("32-byte m");
+        let (ct_m, ss_m) = self.dk.encapsulation_key().encapsulate_deterministic(&m);
+
+        // X25519 half: ephemeral scalar from eseed[32:64]; ct_X is its public key.
+        let eph = shared_to_32(&eseed[32..64]);
+        let ct_x = x25519(eph, X25519_BASEPOINT_BYTES);
+        let ss_x = x25519(eph, pk_x);
+
+        let ss = combiner(ss_m.as_slice(), &ss_x, &ct_x, &pk_x);
+        let mut ct = Vec::with_capacity(DEK_CIPHERTEXT_LEN);
+        ct.extend_from_slice(ct_m.as_slice());
+        ct.extend_from_slice(&ct_x);
+        (ct, ss)
+    }
+
+    /// Decapsulate an X-Wing ciphertext `ct_M ‖ ct_X`, recovering the 32-byte shared secret
+    /// (receiver side). A wrong-length ciphertext is rejected; a foreign ciphertext recovers a
+    /// different pseudo-random secret (ML-KEM implicit rejection), never an error.
     pub fn decapsulate(&self, ciphertext: &[u8]) -> Result<[u8; 32], CryptoError> {
-        let ss = self
+        if ciphertext.len() != DEK_CIPHERTEXT_LEN {
+            return Err(CryptoError::Malformed("X-Wing ciphertext wrong length"));
+        }
+        let (ct_m, ct_x_bytes) = ciphertext.split_at(MLKEM_CT_LEN);
+
+        let ss_m = self
             .dk
-            .decapsulate_slice(ciphertext)
+            .decapsulate_slice(ct_m)
             .map_err(|_| CryptoError::Malformed("ML-KEM ciphertext wrong length"))?;
-        Ok(shared_to_32(ss.as_slice()))
+
+        let ct_x = shared_to_32(ct_x_bytes);
+        let pk_x = self.pk_x();
+        let ss_x = x25519(self.sk_x, ct_x);
+
+        Ok(combiner(ss_m.as_slice(), &ss_x, &ct_x, &pk_x))
     }
 }
 
@@ -101,6 +178,10 @@ impl std::fmt::Debug for DekKeypair {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn hex32(s: &str) -> [u8; 32] {
+        shared_to_32(&hex::decode(s).unwrap())
+    }
 
     #[test]
     fn encapsulate_decapsulate_round_trip() {
@@ -126,8 +207,9 @@ mod tests {
 
     #[test]
     fn wrong_key_recovers_a_different_secret() {
-        // ML-KEM uses implicit rejection: a foreign key decapsulates to a *different*
-        // pseudo-random secret rather than erroring — still cryptographically safe.
+        // X-Wing inherits ML-KEM's implicit rejection and binds the decapsulator's own X25519
+        // key into the combiner, so a foreign key decapsulates to a *different* secret rather
+        // than erroring — still cryptographically safe.
         let alice = DekKeypair::generate();
         let bob = DekKeypair::generate();
         let (ct, k_for_alice) = alice.encapsulate_to_self();
@@ -138,5 +220,50 @@ mod tests {
     fn malformed_ciphertext_is_rejected() {
         let dek = DekKeypair::generate();
         assert!(dek.decapsulate(b"too short").is_err());
+    }
+
+    #[test]
+    fn public_key_and_ciphertext_have_xwing_lengths() {
+        let dek = DekKeypair::generate();
+        assert_eq!(dek.public_bytes().len(), DEK_PUBLIC_LEN, "pk_M ‖ pk_X");
+        let (ct, _) = dek.encapsulate_to_self();
+        assert_eq!(ct.len(), DEK_CIPHERTEXT_LEN, "ct_M ‖ ct_X");
+    }
+
+    #[test]
+    fn x25519_half_is_bound_into_the_secret() {
+        // Corrupting only the X25519 ciphertext tail must change the recovered secret — proof
+        // the classical half genuinely contributes (defence in depth against a broken ML-KEM).
+        let dek = DekKeypair::generate();
+        let (mut ct, k) = dek.encapsulate_to_self();
+        let last = ct.len() - 1;
+        ct[last] ^= 0x01;
+        assert_ne!(dek.decapsulate(&ct).unwrap(), k);
+    }
+
+    #[test]
+    fn xwing_known_answer_vector() {
+        // First test vector from draft-connolly-cfrg-xwing-kem, Appendix C: a 32-byte seed and
+        // 64-byte encapsulation seed pin the public key, ciphertext, and shared secret. This is
+        // the conformance gate proving the combiner byte-order, label, and seed expansion match
+        // the spec (SSoT: Primitives § KEM / Validation — known-answer parity).
+        let seed = hex32("7f9c2ba4e88f827d616045507605853ed73b8093f6efbc88eb1a6eacfa66ef26");
+        let eseed = hex::decode(
+            "3cb1eea988004b93103cfb0aeefd2a686e01fa4a58e8a3639ca8a1e3f9ae57e2\
+             35b8cc873c23dc62b8d260169afa2f75ab916a58d974918835d25e6a435085b2",
+        )
+        .unwrap();
+        let eseed: [u8; ESEED_LEN] = eseed.try_into().unwrap();
+        let expected_ss = hex32("d2df0522128f09dd8e2c92b1e905c793d8f57a54c3da25861f10bf4ca613e384");
+
+        let dek = DekKeypair::from_seed(&seed);
+        let (ct, ss) = dek.encapsulate_to_self_derand(&eseed);
+        assert_eq!(
+            ss, expected_ss,
+            "X-Wing shared secret must match the draft KAT"
+        );
+        assert_eq!(ct.len(), DEK_CIPHERTEXT_LEN);
+        // And the receiver side recovers the same secret from the ciphertext.
+        assert_eq!(dek.decapsulate(&ct).unwrap(), expected_ss);
     }
 }

--- a/capsule-core/src/crypto/keys/keystore.rs
+++ b/capsule-core/src/crypto/keys/keystore.rs
@@ -108,6 +108,13 @@ fn seed64(bytes: Vec<u8>) -> Result<[u8; 64], CryptoError> {
         .map_err(|_| CryptoError::Malformed("sealed key seed wrong length"))
 }
 
+fn seed32(bytes: Vec<u8>) -> Result<[u8; 32], CryptoError> {
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| CryptoError::Malformed("sealed key seed wrong length"))
+}
+
 impl AccountFile {
     /// Decrypt the account with `passphrase`. Returns [`CryptoError::Auth`] on a wrong
     /// passphrase (master unwrap fails) or tampering.
@@ -120,7 +127,7 @@ impl AccountFile {
 
         let user_ik = HybridSigningKey::from_seed64(&seed64(master.open(&self.sealed_ik)?)?);
         let dsk = HybridSigningKey::from_seed64(&seed64(master.open(&self.sealed_dsk)?)?);
-        let dek = DekKeypair::from_seed(&seed64(master.open(&self.sealed_dek)?)?);
+        let dek = DekKeypair::from_seed(&seed32(master.open(&self.sealed_dek)?)?);
 
         Ok(Account {
             user_id: self.user_id,


### PR DESCRIPTION
**Stack: PR 1 of 4** (base `master`). Lands deferred offline data-plane work from `DEFERRED.md`. Each later PR stacks on the previous; review the whole stack together.

## What & why
The device encryption key (DEK) shipped as an **ML-KEM-768-only stand-in**, but the design's `crypto_suite_id = 0x0001` declares the KEM is **X-Wing (X25519 + ML-KEM-768)**. This PR implements the real X-Wing hybrid so the code matches the suite it already claims — neither algorithm being broken alone compromises the shared secret.

## Construction (per `draft-connolly-cfrg-xwing-kem`)
- 32-byte X-Wing seed, `SHAKE256`-expanded to ML-KEM `d‖z` (64) + X25519 scalar (32)
- public key `pk_M ‖ pk_X` = 1216 B; ciphertext `ct_M ‖ ct_X` = 1120 B
- combiner `SHA3-256(ss_M ‖ ss_X ‖ ct_X ‖ pk_X ‖ XWingLabel)` (label last, `5c2e2f2f5e5c`)
- hand-rolled on `ml-kem` + `x25519-dalek` + `sha3` (the `x-wing` crate pulls an incompatible `ml-kem 0.3.0-rc.0` pre-release, duplicating the dep)

The byte-string `encapsulate`/`decapsulate` seam is unchanged, so all callers are unaffected. The keystore now seals the 32-byte DEK seed (was 64).

## Validation
- **Known-answer test** pinned to the draft's Appendix C vector (`seed → ss`) — the conformance gate for combiner byte-order, label, and seed expansion
- X25519-half-binding test (corrupting only `ct_X` changes the recovered secret)
- pk/ct length tests; existing round-trip / seed-reconstruct / wrong-key / malformed tests retained
- `cargo test --workspace --exclude capsule-sdk` green; `cargo clippy -p capsule-core -- -D warnings` green

> Note: the full-workspace `clippy -D warnings` trips one **pre-existing, macOS-only** `unused_mut` in `capsule-api-upload` (reflink path is Linux-gated) — untouched by this branch, clean on the Linux CI.