### PR TITLE
feat(core): multi-epoch album rotation + serializable epoch ledger

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -14,8 +14,9 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
   standalone metadata-blob), **hybrid Ed25519 + ML-DSA-65** signatures (both halves required),
   **X-Wing (X25519 + ML-KEM-768)** hybrid DEK (known-answer-validated against
   `draft-connolly-cfrg-xwing-kem`).
-- **Key hierarchy** — master key, default-album-id derivation, AMKs + per-file/blob keys,
-  software keystore (account ↔ encrypted `AccountFile`), signed device directory.
+- **Key hierarchy** — master key, default-album-id derivation, multi-epoch AMKs (offline
+  rotation) + per-file/blob keys, software keystore (account ↔ encrypted `AccountFile`), signed
+  device directory.
 - **Encryption** — STREAM asset encryption with independent ranged-chunk decryption;
   exact metadata-blob wire format.
 - **Provenance** — signed `AssetManifest`/`DerivativeManifest`, append-only hash-chained
@@ -39,9 +40,13 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
   consumes (epoch ceiling, per-epoch write-tier pubkey, AMK presence, admin-chain validity).
   `ReferenceAuthority` (an admin-signed epoch ledger) stands in for live MLS and is honored
   only via `&dyn AlbumAuthority`, so an `OpenMlsAuthority` drops in unchanged.
-- **Consequence:** albums are **single-epoch** in the offline core. Epoch rotation,
-  membership add/remove, the `Welcome`/history-delivery flow, and the album upgrade ceremony
-  are deferred with OpenMLS.
+- **Now implemented offline:** **multi-epoch rotation** via `ReferenceAuthority` —
+  `Workspace::rotate_epoch` mints AMK_v{n+1} + a fresh write-tier key and admin-attests the new
+  epoch (assets imported before a rotation stay verifiable under their original epoch), plus a
+  serializable, admin-signed `SignedEpochLedger` (`to_ledger`/`from_ledger`, whose admin chain is
+  re-verified on reload; the local-only AMK-presence flag is restored out-of-band).
+- **Still deferred with OpenMLS:** membership add/remove, the `Welcome`/history-delivery flow,
+  and the album upgrade ceremony — these need live MLS group state, not just the epoch ledger.
 
 ### Hardware-bound key storage
 - Device keys are kept in a **software keystore** (private keys sealed under the

--- a/capsule-core/src/crypto/authority/reference.rs
+++ b/capsule-core/src/crypto/authority/reference.rs
@@ -12,9 +12,9 @@
 //! - Minting an epoch sets the write-tier key and (optionally) the AMK presence **together**
 //!   — the design's "AMK epoch bump + write-tier rotation are one commit" atomicity.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::AlbumAuthority;
@@ -34,6 +34,32 @@ struct Entry {
     write_tier_pub: HybridVerifyingKey,
     admin_sig: HybridSignature,
     amk_present: bool,
+}
+
+/// The portable, admin-signed epoch ledger: every attested `(epoch, write_tier_pub)` with its
+/// admin signature. `amk_present` is **local-only** state and deliberately is *not* part of this
+/// signed artifact — on reload it is restored from the epochs a device actually holds AMKs for.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SignedEpochLedger {
+    /// Album this ledger speaks for.
+    pub album_id: Uuid,
+    /// The admin-tier public key every entry is signed under.
+    pub admin_pub: HybridVerifyingKey,
+    /// The attested epoch ceiling (must equal the max attested epoch).
+    pub ceiling: u32,
+    /// One entry per attested epoch.
+    pub entries: Vec<LedgerEntry>,
+}
+
+/// One epoch's signed attestation within a [`SignedEpochLedger`].
+#[derive(Clone, Serialize, Deserialize)]
+pub struct LedgerEntry {
+    /// Epoch number (`amk_version`).
+    pub epoch: u32,
+    /// The write-tier public key attested for this epoch.
+    pub write_tier_pub: HybridVerifyingKey,
+    /// The admin signature over `(album_id, epoch, write_tier_pub)`.
+    pub admin_sig: HybridSignature,
 }
 
 /// A reference album authority backed by an admin-signed epoch ledger.
@@ -115,6 +141,53 @@ impl ReferenceAuthority {
         if let Some(e) = self.entries.get_mut(&epoch.0) {
             e.amk_present = true;
         }
+    }
+
+    /// Export the admin-signed epoch ledger for persistence or transport. The local-only
+    /// AMK-presence flags are excluded — they are not part of the signed history.
+    pub fn to_ledger(&self) -> SignedEpochLedger {
+        SignedEpochLedger {
+            album_id: self.album_id,
+            admin_pub: self.admin_pub.clone(),
+            ceiling: self.ceiling.0,
+            entries: self
+                .entries
+                .iter()
+                .map(|(epoch, e)| LedgerEntry {
+                    epoch: *epoch,
+                    write_tier_pub: e.write_tier_pub.clone(),
+                    admin_sig: e.admin_sig.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Rebuild an authority from a serialized ledger, **re-verifying the entire admin chain**.
+    /// `held_epochs` are the epochs whose AMK content key this device actually holds, restoring
+    /// the local-only `amk_present` state. Returns `None` if the admin chain does not verify (a
+    /// tampered, forged, or rewound ledger).
+    pub fn from_ledger(ledger: &SignedEpochLedger, held_epochs: &BTreeSet<u32>) -> Option<Self> {
+        let entries = ledger
+            .entries
+            .iter()
+            .map(|le| {
+                (
+                    le.epoch,
+                    Entry {
+                        write_tier_pub: le.write_tier_pub.clone(),
+                        admin_sig: le.admin_sig.clone(),
+                        amk_present: held_epochs.contains(&le.epoch),
+                    },
+                )
+            })
+            .collect();
+        let authority = Self {
+            album_id: ledger.album_id,
+            admin_pub: ledger.admin_pub.clone(),
+            ceiling: AmkVersion(ledger.ceiling),
+            entries,
+        };
+        authority.admin_chain_verifies().then_some(authority)
     }
 }
 
@@ -251,5 +324,43 @@ mod tests {
         // Fabricate a higher ceiling than any attested epoch.
         auth.ceiling = AmkVersion(5);
         assert!(!auth.admin_chain_verifies());
+    }
+
+    #[test]
+    fn ledger_round_trip_reverifies_and_restores_amk_presence() {
+        let (album, admin, w1, w2) = setup();
+        let auth = ReferenceAuthority::new(album, admin.verifying_key())
+            .with_epoch(&admin, AmkVersion(1), &w1.verifying_key(), true)
+            .with_epoch(&admin, AmkVersion(2), &w2.verifying_key(), false);
+
+        // Serialize → canonical CBOR → deserialize preserves the ledger.
+        let bytes = cbor::to_canonical_vec(&auth.to_ledger()).unwrap();
+        let decoded: SignedEpochLedger = cbor::from_slice(&bytes).unwrap();
+
+        // Rebuild holding only epoch 1's AMK locally (presence is restored out-of-band).
+        let restored = ReferenceAuthority::from_ledger(&decoded, &BTreeSet::from([1])).unwrap();
+        assert!(restored.admin_chain_verifies());
+        assert_eq!(restored.epoch_ceiling(), AmkVersion(2));
+        assert_eq!(
+            restored.write_tier_pubkey(AmkVersion(2)),
+            Some(w2.verifying_key())
+        );
+        assert!(restored.has_amk(AmkVersion(1)));
+        assert!(!restored.has_amk(AmkVersion(2)));
+    }
+
+    #[test]
+    fn tampered_ledger_is_rejected_on_reload() {
+        let (album, admin, w1, w2) = setup();
+        let auth = ReferenceAuthority::new(album, admin.verifying_key()).with_epoch(
+            &admin,
+            AmkVersion(1),
+            &w1.verifying_key(),
+            true,
+        );
+        // Swap in a different write-tier key with no matching admin re-signature.
+        let mut ledger = auth.to_ledger();
+        ledger.entries[0].write_tier_pub = w2.verifying_key();
+        assert!(ReferenceAuthority::from_ledger(&ledger, &BTreeSet::from([1])).is_none());
     }
 }

--- a/capsule-core/src/lifecycle.rs
+++ b/capsule-core/src/lifecycle.rs
@@ -17,8 +17,9 @@
 //!   regenerated deterministically from the manifest's recorded nonce prefix.
 //!
 //! Clients store **plaintext** locally (original + signed sidecar + provenance chain);
-//! encryption produces the artifacts that cross a boundary. Album epoch rotation (the MLS
-//! ceremony) is deferred — albums here are single-epoch (see `DEFERRED.md`).
+//! encryption produces the artifacts that cross a boundary. Offline epoch rotation is supported
+//! ([`rotate_epoch`](Workspace::rotate_epoch)); the MLS membership ceremony (`Welcome`,
+//! add/remove) remains deferred (see `DEFERRED.md`).
 //!
 //! [`verify_asset`]: crate::crypto::verify_asset
 
@@ -73,7 +74,7 @@ pub enum LifecycleError {
 
 type Result<T> = std::result::Result<T, LifecycleError>;
 
-/// One album's key material (single-epoch in this offline core).
+/// One album's key material across one or more epochs.
 pub struct AlbumKeys {
     /// Album id.
     pub album_id: Uuid,
@@ -85,7 +86,7 @@ pub struct AlbumKeys {
     pub write_tier: HybridSigningKey,
     /// Per-album admin signing key.
     pub admin: HybridSigningKey,
-    /// The current (and only) epoch.
+    /// The current (highest) epoch — the one new imports are written under.
     pub current_epoch: u32,
 }
 
@@ -239,6 +240,39 @@ impl Workspace {
         album_id
     }
 
+    /// Rotate `album_id` to a fresh epoch: mint AMK_v{n+1} and a new write-tier key, have the
+    /// album admin attest the new epoch, and advance the current epoch — the design's
+    /// "AMK bump + write-tier rotation are one commit" atomicity. The admin key (the ledger
+    /// root) is stable across epochs, and existing assets stay verifiable under their original
+    /// epoch. Returns the new epoch. Membership changes / the MLS `Welcome` flow remain deferred
+    /// (see `DEFERRED.md`).
+    pub fn rotate_epoch(&mut self, album_id: Uuid) -> Result<u32> {
+        let next = {
+            let album = self
+                .albums
+                .get_mut(&album_id)
+                .ok_or_else(|| LifecycleError::NotFound(format!("album {album_id}")))?;
+            let next = album.current_epoch + 1;
+            album.amks.insert(next, *Amk::generate().as_bytes());
+            album.write_tier = HybridSigningKey::generate();
+            album.current_epoch = next;
+            next
+        };
+        // Disjoint fields: read the album's keys while mutably attesting in its authority.
+        let album = self.albums.get(&album_id).expect("album just mutated");
+        let authority = self
+            .authorities
+            .get_mut(&album_id)
+            .ok_or_else(|| LifecycleError::NotFound(format!("authority {album_id}")))?;
+        authority.attest_epoch(
+            &album.admin,
+            AmkVersion(next),
+            &album.write_tier.verifying_key(),
+            true,
+        );
+        Ok(next)
+    }
+
     fn album(&self, album_id: &Uuid) -> Result<&AlbumKeys> {
         self.albums
             .get(album_id)
@@ -260,8 +294,11 @@ impl Workspace {
         ))
     }
 
-    fn file_key(&self, album: &AlbumKeys, file_id: &Uuid) -> [u8; 32] {
-        let amk = Amk::from_bytes(album.amks[&album.current_epoch]);
+    /// Derive the per-file key under a *specific* epoch's AMK. Callers pass the epoch the asset
+    /// was written under (`amk_version`), never assuming the album's current epoch — so an asset
+    /// imported before a rotation still derives the key it was encrypted with.
+    fn file_key(&self, album: &AlbumKeys, epoch: u32, file_id: &Uuid) -> [u8; 32] {
+        let amk = Amk::from_bytes(album.amks[&epoch]);
         amk.derive_file_key(file_id)
     }
 
@@ -312,7 +349,7 @@ impl Workspace {
         let capture_utc = Utc::now().timestamp();
 
         let album = self.album(&album_id)?;
-        let file_key = self.file_key(album, &asset_id);
+        let file_key = self.file_key(album, album.current_epoch, &asset_id);
         let (enc, ciphertext) = stream::encrypt_asset_vec_full(&file_key, &plaintext);
 
         let core = ManifestCore {
@@ -401,7 +438,7 @@ impl Workspace {
         let head = &asset.chain.records().last().unwrap().manifest;
         let plaintext =
             fs::read(self.media_path(asset)).map_err(|e| LifecycleError::Io(e.to_string()))?;
-        let file_key = self.file_key(album, &head.core.file_id);
+        let file_key = self.file_key(album, head.core.amk_version.0, &head.core.file_id);
         let (_, ciphertext) =
             stream::encrypt_asset_vec_with_prefix(&file_key, head.core.nonce_prefix, &plaintext);
 
@@ -517,21 +554,19 @@ impl Workspace {
             let head = &asset.chain.records().last().unwrap().manifest;
             let plaintext =
                 fs::read(self.media_path(asset)).map_err(|e| LifecycleError::Io(e.to_string()))?;
-            let file_key = self.file_key(album, &head.core.file_id);
+            let epoch = head.core.amk_version.0;
+            let file_key = self.file_key(album, epoch, &head.core.file_id);
             let (_, ciphertext) = stream::encrypt_asset_vec_with_prefix(
                 &file_key,
                 head.core.nonce_prefix,
                 &plaintext,
             );
-            let amk = Amk::from_bytes(album.amks[&album.current_epoch]);
+            let amk = Amk::from_bytes(album.amks[&epoch]);
             let metadata_blob = seal_blob(
                 &amk.derive_blob_key(&asset.asset_id),
                 &asset.sidecar.to_canonical_vec(),
             );
-            amks.insert(
-                (asset.album_id, head.core.amk_version.0),
-                album.amks[&album.current_epoch],
-            );
+            amks.insert((asset.album_id, epoch), album.amks[&epoch]);
             assets.push(BackupAsset {
                 album_id: asset.album_id,
                 asset_id: asset.asset_id,
@@ -756,6 +791,59 @@ mod tests {
         assert!(
             ws3.import_backup(&backup_path, b"recovery-pass", &imposter)
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn epoch_rotation_keeps_old_assets_verifiable_and_backs_up() {
+        let lib = TempDir::new().unwrap();
+        let src = TempDir::new().unwrap();
+        let a = src.path().join("a.jpg");
+        let b = src.path().join("b.jpg");
+        fs::write(&a, b"\xFF\xD8\xFF first photo, written at epoch 1").unwrap();
+        fs::write(&b, b"\xFF\xD8\xFF second photo, written at epoch 2").unwrap();
+
+        let mut ws = fast_workspace(lib.path());
+        let album = ws.create_album("Trip");
+
+        // Import at epoch 1, rotate the album, import at epoch 2.
+        let id_a = ws.import_asset(album, &a).unwrap();
+        assert_eq!(ws.rotate_epoch(album).unwrap(), 2);
+        let id_b = ws.import_asset(album, &b).unwrap();
+
+        // Each asset recorded the epoch it was written under...
+        let epoch_of = |ws: &Workspace, id| {
+            ws.asset(id).unwrap().chain.records()[0]
+                .manifest
+                .core
+                .amk_version
+        };
+        assert_eq!(epoch_of(&ws, &id_a), AmkVersion(1));
+        assert_eq!(epoch_of(&ws, &id_b), AmkVersion(2));
+        // ...and BOTH still verify — the pre-rotation asset under its original epoch key (the
+        // regression guard for the `current_epoch` file-key bug).
+        assert_eq!(ws.verify(&id_a).unwrap(), VerifyOutcome::Accept);
+        assert_eq!(ws.verify(&id_b).unwrap(), VerifyOutcome::Accept);
+
+        // A cross-epoch backup escrows each asset's own-epoch AMK; restore into a fresh library
+        // is byte-equal for both (guards the export file-key / blob-key / escrow-value epochs).
+        let backup_path = src.path().join("backup.tar");
+        ws.export_backup(&backup_path, b"recovery-pass").unwrap();
+        let exporter_pub = ws.exporter_verifying_key();
+
+        let fresh = TempDir::new().unwrap();
+        let mut ws2 = fast_workspace(fresh.path());
+        let added = ws2
+            .import_backup(&backup_path, b"recovery-pass", &exporter_pub)
+            .unwrap();
+        assert_eq!(added, 2);
+        assert_eq!(
+            ws2.read_plaintext(&id_a).unwrap(),
+            ws.read_plaintext(&id_a).unwrap()
+        );
+        assert_eq!(
+            ws2.read_plaintext(&id_b).unwrap(),
+            ws.read_plaintext(&id_b).unwrap()
         );
     }
 }


### PR DESCRIPTION
**Stack: PR 2 of 4** — base is `feat/xwing-dek` (PR 1). Review after #327.

## What & why
Albums were single-epoch in the offline core. The `ReferenceAuthority` (admin-signed epoch ledger) and `AlbumKeys.amks` already modelled multiple epochs; this PR adds the rotation operation, persistence, and fixes the latent single-epoch assumptions that surface once an album actually rotates. **Real MLS membership/`Welcome` stays deferred** — this is the offline, same-membership rotation the reference authority can model honestly.

## Changes
- **`Workspace::rotate_epoch`** — mints AMK_v{n+1} + a fresh write-tier key, admin-attests the new epoch, advances `current_epoch`, atomically. The admin key is the stable ledger root; pre-rotation assets stay verifiable under their original epoch.
- **`SignedEpochLedger`** (`to_ledger`/`from_ledger`) — a serializable, admin-signed ledger whose admin chain is **re-verified on reload**; the local-only AMK-presence flag is restored out-of-band from the epochs a device actually holds.
- **Three latent single-epoch bug fixes** in `lifecycle.rs`: `file_key` now takes the asset's explicit `amk_version` instead of `current_epoch`; `export_backup` derives the file key, the metadata-blob key, **and** escrows the AMK value under each asset's own epoch (all three previously read `current_epoch`, corrupting cross-epoch backups).

## Validation
- rotate → import under the new epoch → **both** old and new assets `verify == Accept` (the regression guard for the file-key bug)
- **cross-epoch backup** restores byte-equal into a fresh library (guards the export file-key / blob-key / escrow-value epochs)
- ledger round-trips through canonical CBOR and re-verifies; a tampered ledger (swapped write-tier key, no re-signature) is rejected on reload
- `cargo test --workspace --exclude capsule-sdk` green; `cargo clippy -p capsule-core -- -D warnings` green