### PR TITLE
feat(core): adaptive cache-eviction sweep (issue #23)

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -59,11 +59,13 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
   refuse-by-default validation invariants those paths need are implemented in
   `capsule_core::validation` and ready to wire into `capsule-api`.
 - The **adaptive cache-eviction policy** (bounded budget, LRU-by-last-access retention of
-  recently-viewed blobs, tier-ordered eviction original → preview → thumbnail) is specified in
-  `capsule-docs` [Filesystem — Client → Space Recovery] but **not yet implemented** (issue #23,
-  scoped to documentation). Seam: last-access tracking lives in `capsule-core::db`
-  (`library.sqlite`) and the sweep in `capsule-core::library`, driven by `capsule-sdk`
-  connection-class detection — no core data-plane rework needed to land it.
+  recently-viewed blobs, tier-ordered eviction original → preview → thumbnail, pinned and
+  device-owned originals exempt) is **now implemented** (issue #23): the
+  `cached_representations` table + last-access tracking live in `capsule-core::db` and the sweep
+  `capsule_core::library::cache_sweep` deletes evicted cache files (never the canonical `media/`
+  files or the index). The byte budget is a plain parameter, so `capsule-sdk` connection-class
+  detection drives it unchanged. Still deferred upstream: that connection-class budget detection
+  and the wider networked server/client (HTTP/TUS, GraphQL, `/sync`, federation, peering).
 
 ### ML / AI
 - Embeddings, `sqlite-vec` vector search, the model registry, semantic/face features, and

--- a/capsule-core/src/db/driver.rs
+++ b/capsule-core/src/db/driver.rs
@@ -1,4 +1,4 @@
-use crate::db::rows::{AssetRow, AssetStackRow, StackMemberRow};
+use crate::db::rows::{AssetRow, AssetStackRow, CachedRepresentationRow, StackMemberRow};
 use crate::db::schema;
 use rusqlite::{Connection, params};
 use std::path::Path;
@@ -236,6 +236,80 @@ impl DatabaseDriver {
         let rows = stmt.query_map(params![threshold], map_asset_row)?;
         rows.collect()
     }
+
+    // ── Cached representations (adaptive cache eviction, issue #23) ──────────────
+
+    /// Insert or replace a cached representation row.
+    pub fn upsert_representation(
+        &self,
+        row: &CachedRepresentationRow,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO cached_representations
+             (uuid, tier, format, bytes, path, last_accessed_at, pinned, is_owned_original)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+            params![
+                row.uuid,
+                row.tier,
+                row.format,
+                row.bytes,
+                row.path,
+                row.last_accessed_at,
+                row.pinned as i64,
+                row.is_owned_original as i64,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Remove a cached representation row (after its file has been deleted).
+    pub fn remove_representation(&self, uuid: &str, tier: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "DELETE FROM cached_representations WHERE uuid = ?1 AND tier = ?2",
+            params![uuid, tier],
+        )?;
+        Ok(())
+    }
+
+    /// Stamp a representation's last-access time (recency promotion) — viewing an asset keeps its
+    /// representations from eviction. `now` is injected so the policy stays deterministic.
+    pub fn record_access(&self, uuid: &str, tier: &str, now: i64) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE cached_representations SET last_accessed_at = ?1 WHERE uuid = ?2 AND tier = ?3",
+            params![now, uuid, tier],
+        )?;
+        Ok(())
+    }
+
+    /// The reclaimable representations to evict so the reclaimable set fits within `budget_bytes`.
+    /// Pinned and device-owned originals are never candidates. Rows are ranked most-valuable-to-
+    /// keep first (most-recently-accessed; thumbnail over preview over original at equal recency),
+    /// then everything past the budget is evicted — i.e. least-recently-accessed first, original →
+    /// preview → thumbnail at equal recency.
+    pub fn eviction_candidates(
+        &self,
+        budget_bytes: i64,
+    ) -> Result<Vec<CachedRepresentationRow>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT uuid, tier, format, bytes, path, last_accessed_at, pinned, is_owned_original
+             FROM cached_representations
+             WHERE pinned = 0 AND is_owned_original = 0
+             ORDER BY last_accessed_at DESC,
+                      CASE tier WHEN 'thumbnail' THEN 2 WHEN 'preview' THEN 1 WHEN 'original' THEN 0 ELSE -1 END DESC",
+        )?;
+        let keep_first = stmt.query_map([], map_cached_representation_row)?;
+
+        let mut kept_bytes: i64 = 0;
+        let mut evict = Vec::new();
+        for row in keep_first {
+            let row = row?;
+            kept_bytes += row.bytes;
+            if kept_bytes > budget_bytes {
+                evict.push(row);
+            }
+        }
+        Ok(evict)
+    }
 }
 
 fn now_secs() -> i64 {
@@ -265,6 +339,21 @@ fn map_asset_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AssetRow> {
         rating: row.get(15)?,
         is_deleted: row.get::<_, i64>(16)? != 0,
         deleted_at: row.get(17)?,
+    })
+}
+
+fn map_cached_representation_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<CachedRepresentationRow> {
+    Ok(CachedRepresentationRow {
+        uuid: row.get(0)?,
+        tier: row.get(1)?,
+        format: row.get(2)?,
+        bytes: row.get(3)?,
+        path: row.get(4)?,
+        last_accessed_at: row.get(5)?,
+        pinned: row.get::<_, i64>(6)? != 0,
+        is_owned_original: row.get::<_, i64>(7)? != 0,
     })
 }
 
@@ -300,7 +389,7 @@ mod tests {
     fn test_init_schema_idempotent() {
         let db = DatabaseDriver::open_in_memory().unwrap();
         db.init_schema().unwrap(); // second call — should not fail
-        assert_eq!(db.schema_version().unwrap(), 1);
+        assert_eq!(db.schema_version().unwrap(), 2);
     }
 
     #[test]
@@ -421,5 +510,92 @@ mod tests {
         db.upsert_asset(&asset).unwrap();
         let found = db.find_by_hash(&"a".repeat(64)).unwrap().unwrap();
         assert_eq!(found.rating, 5);
+    }
+
+    fn rep(uuid: &str, tier: &str, bytes: i64, last: i64) -> CachedRepresentationRow {
+        CachedRepresentationRow {
+            uuid: uuid.to_string(),
+            tier: tier.to_string(),
+            format: None,
+            bytes,
+            path: format!("/cache/{uuid}.{tier}"),
+            last_accessed_at: last,
+            pinned: false,
+            is_owned_original: false,
+        }
+    }
+
+    fn evicted_ids(rows: &[CachedRepresentationRow]) -> Vec<&str> {
+        rows.iter().map(|r| r.uuid.as_str()).collect()
+    }
+
+    #[test]
+    fn eviction_is_least_recently_accessed_first() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        db.upsert_representation(&rep("a", "thumbnail", 100, 10))
+            .unwrap();
+        db.upsert_representation(&rep("b", "thumbnail", 100, 20))
+            .unwrap();
+        db.upsert_representation(&rep("c", "thumbnail", 100, 30))
+            .unwrap();
+        // 300 B reclaimable, budget 250 → evict only the least-recently-accessed.
+        let evicted = db.eviction_candidates(250).unwrap();
+        assert_eq!(evicted_ids(&evicted), ["a"]);
+    }
+
+    #[test]
+    fn eviction_tier_order_breaks_recency_ties() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        // Equal recency, three tiers — original (biggest, most regenerable) is evicted first.
+        db.upsert_representation(&rep("x", "original", 100, 50))
+            .unwrap();
+        db.upsert_representation(&rep("x", "preview", 100, 50))
+            .unwrap();
+        db.upsert_representation(&rep("x", "thumbnail", 100, 50))
+            .unwrap();
+        let evicted = db.eviction_candidates(250).unwrap();
+        assert_eq!(
+            evicted.iter().map(|r| r.tier.as_str()).collect::<Vec<_>>(),
+            ["original"]
+        );
+    }
+
+    #[test]
+    fn recency_promotion_protects_touched_representation() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        db.upsert_representation(&rep("a", "thumbnail", 100, 10))
+            .unwrap();
+        db.upsert_representation(&rep("b", "thumbnail", 100, 20))
+            .unwrap();
+        db.upsert_representation(&rep("c", "thumbnail", 100, 30))
+            .unwrap();
+        // Viewing the oldest makes it newest, so the next-oldest is evicted instead.
+        db.record_access("a", "thumbnail", 100).unwrap();
+        let evicted = db.eviction_candidates(250).unwrap();
+        assert_eq!(evicted_ids(&evicted), ["b"]);
+    }
+
+    #[test]
+    fn pinned_and_owned_originals_are_exempt() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        let mut pinned = rep("p", "original", 1000, 10);
+        pinned.pinned = true;
+        let mut owned = rep("o", "original", 1000, 10);
+        owned.is_owned_original = true;
+        db.upsert_representation(&pinned).unwrap();
+        db.upsert_representation(&owned).unwrap();
+        db.upsert_representation(&rep("c", "thumbnail", 100, 30))
+            .unwrap();
+        // Budget 0 reclaims everything reclaimable, but the exempt rows survive the sweep.
+        let evicted = db.eviction_candidates(0).unwrap();
+        assert_eq!(evicted_ids(&evicted), ["c"]);
+    }
+
+    #[test]
+    fn eviction_empty_when_within_budget() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        db.upsert_representation(&rep("a", "thumbnail", 100, 10))
+            .unwrap();
+        assert!(db.eviction_candidates(1000).unwrap().is_empty());
     }
 }

--- a/capsule-core/src/db/mod.rs
+++ b/capsule-core/src/db/mod.rs
@@ -3,4 +3,4 @@ pub mod rows;
 pub mod schema;
 
 pub use driver::DatabaseDriver;
-pub use rows::{AssetRow, AssetStackRow, AssetTagRow, StackMemberRow};
+pub use rows::{AssetRow, AssetStackRow, AssetTagRow, CachedRepresentationRow, StackMemberRow};

--- a/capsule-core/src/db/rows.rs
+++ b/capsule-core/src/db/rows.rs
@@ -47,3 +47,20 @@ pub struct AssetTagRow {
     pub uuid: String,
     pub tag: String,
 }
+
+/// One cached, reclaimable representation of an asset. The eviction sweep ranks these by
+/// `last_accessed_at` (LRU) with `tier` as the tiebreaker; `pinned` and `is_owned_original`
+/// rows are exempt. `path` is the on-disk cache file the sweep deletes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CachedRepresentationRow {
+    pub uuid: String,
+    /// `"original"` | `"preview"` | `"thumbnail"`.
+    pub tier: String,
+    pub format: Option<String>,
+    pub bytes: i64,
+    pub path: String,
+    pub last_accessed_at: i64,
+    pub pinned: bool,
+    /// An original this device itself owns as source of truth — never auto-evicted.
+    pub is_owned_original: bool,
+}

--- a/capsule-core/src/db/schema.rs
+++ b/capsule-core/src/db/schema.rs
@@ -1,4 +1,4 @@
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 pub const DDL: &str = r#"
 PRAGMA journal_mode = WAL;
@@ -62,4 +62,24 @@ CREATE INDEX IF NOT EXISTS idx_stacks_primary    ON asset_stacks(primary_asset_i
 CREATE INDEX IF NOT EXISTS idx_stack_members_stack  ON stack_members(stack_id);
 CREATE INDEX IF NOT EXISTS idx_stack_members_asset  ON stack_members(asset_id);
 CREATE INDEX IF NOT EXISTS idx_tags_tag          ON asset_tags(tag);
+
+-- Reclaimable cached representations of an asset (the cache/ tier — thumbnails, previews,
+-- transcodes — plus fetched-but-unpinned originals). Eviction is LRU by last_accessed_at,
+-- tier original → preview → thumbnail at equal recency; pinned and device-owned originals are
+-- exempt. Authoritative local state (re-scannable from disk), untouched by index rebuild.
+-- SSoT: design/filesystem/client § Space Recovery.
+CREATE TABLE IF NOT EXISTS cached_representations (
+    uuid              TEXT    NOT NULL,
+    tier              TEXT    NOT NULL,
+    format            TEXT,
+    bytes             INTEGER NOT NULL,
+    path              TEXT    NOT NULL,
+    last_accessed_at  INTEGER NOT NULL,
+    pinned            INTEGER NOT NULL DEFAULT 0,
+    is_owned_original INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (uuid, tier)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cache_evict
+    ON cached_representations(pinned, is_owned_original, last_accessed_at);
 "#;

--- a/capsule-core/src/library/cache.rs
+++ b/capsule-core/src/library/cache.rs
@@ -1,0 +1,104 @@
+//! Adaptive cache eviction — the client-side "Space Recovery" sweep.
+//!
+//! Keeps the reclaimable cache (the `cache/` tree plus fetched-but-unpinned originals) within a
+//! byte budget by evicting least-recently-accessed representations first, with tier order
+//! (original → preview → thumbnail) breaking recency ties. Pinned representations, device-owned
+//! originals, the canonical `media/` files, and the `library.sqlite` index are never touched.
+//! The budget is a plain parameter so `capsule-sdk` connection-class detection can drive it.
+//!
+//! SSoT: design/filesystem/client § Space Recovery.
+
+use std::fs;
+use std::path::Path;
+
+use crate::db::DatabaseDriver;
+use crate::db::rows::CachedRepresentationRow;
+
+/// What an eviction sweep reclaimed.
+#[derive(Debug, Default, PartialEq)]
+pub struct EvictionReport {
+    /// The representations evicted, worst-first (least-recently-accessed).
+    pub evicted: Vec<CachedRepresentationRow>,
+    /// Total bytes reclaimed.
+    pub bytes_reclaimed: i64,
+}
+
+/// Reclaim cached representations until the reclaimable set fits within `budget_bytes`. Deletes
+/// each evicted representation's cache file from disk and removes its index row. A cache file that
+/// is already gone is treated as reclaimed (not an error) and its stale row is still dropped.
+/// Pinned and device-owned originals are never evicted by this automatic path; canonical `media/`
+/// files are never candidates (they are not tracked in `cached_representations`).
+pub fn cache_sweep(
+    db: &DatabaseDriver,
+    budget_bytes: i64,
+) -> Result<EvictionReport, rusqlite::Error> {
+    let candidates = db.eviction_candidates(budget_bytes)?;
+    let mut report = EvictionReport::default();
+    for row in candidates {
+        let _ = fs::remove_file(Path::new(&row.path));
+        db.remove_representation(&row.uuid, &row.tier)?;
+        report.bytes_reclaimed += row.bytes;
+        report.evicted.push(row);
+    }
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn sweep_deletes_cache_files_and_rows_but_not_canonical_media() {
+        let dir = TempDir::new().unwrap();
+        let db = DatabaseDriver::open_in_memory().unwrap();
+
+        // A reclaimable thumbnail file and a canonical media file that must survive.
+        let thumb = dir.path().join("thumb.jpg");
+        let canonical = dir.path().join("original.jpg");
+        fs::write(&thumb, vec![0u8; 500]).unwrap();
+        fs::write(&canonical, b"canonical bytes").unwrap();
+
+        db.upsert_representation(&CachedRepresentationRow {
+            uuid: "a".to_string(),
+            tier: "thumbnail".to_string(),
+            format: Some("jpg".to_string()),
+            bytes: 500,
+            path: thumb.to_string_lossy().into_owned(),
+            last_accessed_at: 1,
+            pinned: false,
+            is_owned_original: false,
+        })
+        .unwrap();
+
+        // Budget 0 → reclaim everything reclaimable.
+        let report = cache_sweep(&db, 0).unwrap();
+        assert_eq!(report.evicted.len(), 1);
+        assert_eq!(report.bytes_reclaimed, 500);
+        assert!(!thumb.exists(), "evicted cache file is deleted");
+        assert!(canonical.exists(), "canonical media is untouched");
+        assert!(
+            db.eviction_candidates(0).unwrap().is_empty(),
+            "the index row is removed"
+        );
+    }
+
+    #[test]
+    fn sweep_missing_file_is_not_an_error() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        db.upsert_representation(&CachedRepresentationRow {
+            uuid: "gone".to_string(),
+            tier: "preview".to_string(),
+            format: None,
+            bytes: 10,
+            path: "/nonexistent/path/preview.bin".to_string(),
+            last_accessed_at: 1,
+            pinned: false,
+            is_owned_original: false,
+        })
+        .unwrap();
+        let report = cache_sweep(&db, 0).unwrap();
+        assert_eq!(report.evicted.len(), 1);
+        assert!(db.eviction_candidates(0).unwrap().is_empty());
+    }
+}

--- a/capsule-core/src/library/init.rs
+++ b/capsule-core/src/library/init.rs
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(ver.version, CURRENT_LIBRARY_VERSION);
 
         // SQLite has the correct schema version
-        assert_eq!(lib.db.schema_version().unwrap(), 1);
+        assert_eq!(lib.db.schema_version().unwrap(), 2);
 
         // Config has the correct library name
         assert_eq!(lib.config().library_name, "My Library");

--- a/capsule-core/src/library/mod.rs
+++ b/capsule-core/src/library/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod error;
 pub mod init;
 #[allow(clippy::module_inception)]
@@ -9,6 +10,7 @@ pub mod rebuild;
 pub mod scrub;
 pub mod trash;
 
+pub use cache::{EvictionReport, cache_sweep};
 pub use error::LibraryError;
 pub use init::init_library;
 pub use library::Library;


### PR DESCRIPTION
**Stack: PR 3 of 4** — base is `feat/epoch-rotation` (PR 2). Review after #328.

## What & why
Implements the **Space Recovery** policy from `design/filesystem/client` (issue #23), which was specified (and even had its unit tests enumerated) but unimplemented. Pure SQLite + filesystem + injected clock — no media decode involved.

## Policy
Keep the reclaimable cache within a byte budget, evicting **least-recently-accessed first**, with tier order **original → preview → thumbnail** breaking recency ties. **Pinned** representations and **device-owned originals** are exempt; canonical `media/` files and the `library.sqlite` index are never touched.

## Changes
- `cached_representations` table + `SCHEMA_VERSION 1 → 2` (additive `CREATE TABLE IF NOT EXISTS`; `rebuild_index` leaves these rows intact — they're authoritative local state with no sidecar source)
- `DatabaseDriver`: `upsert_representation`, `remove_representation`, `record_access` (recency promotion, injected `now`), and the pure `eviction_candidates(budget)` selector
- `library::cache_sweep` deletes evicted cache files and drops their rows
- the byte budget is a plain parameter, so `capsule-sdk` connection-class detection (still deferred upstream) drives it unchanged

## Validation
Mirrors the doc's enumerated tests: LRU order, tier-order tiebreak, recency promotion, pin + owned-original exemption, plus a `TempDir` sweep asserting cache files are deleted while canonical media survives. `cargo test --workspace --exclude capsule-sdk` green; `cargo clippy -p capsule-core -- -D warnings` green.