### PR TITLE
feat(core): index the crypto lifecycle into library.sqlite

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -14,8 +14,9 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
   standalone metadata-blob), **hybrid Ed25519 + ML-DSA-65** signatures (both halves required),
   **X-Wing (X25519 + ML-KEM-768)** hybrid DEK (known-answer-validated against
   `draft-connolly-cfrg-xwing-kem`).
-- **Key hierarchy** — master key, default-album-id derivation, AMKs + per-file/blob keys,
-  software keystore (account ↔ encrypted `AccountFile`), signed device directory.
+- **Key hierarchy** — master key, default-album-id derivation, multi-epoch AMKs (offline
+  rotation) + per-file/blob keys, software keystore (account ↔ encrypted `AccountFile`), signed
+  device directory.
 - **Encryption** — STREAM asset encryption with independent ranged-chunk decryption;
   exact metadata-blob wire format.
 - **Provenance** — signed `AssetManifest`/`DerivativeManifest`, append-only hash-chained
@@ -39,9 +40,13 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
   consumes (epoch ceiling, per-epoch write-tier pubkey, AMK presence, admin-chain validity).
   `ReferenceAuthority` (an admin-signed epoch ledger) stands in for live MLS and is honored
   only via `&dyn AlbumAuthority`, so an `OpenMlsAuthority` drops in unchanged.
-- **Consequence:** albums are **single-epoch** in the offline core. Epoch rotation,
-  membership add/remove, the `Welcome`/history-delivery flow, and the album upgrade ceremony
-  are deferred with OpenMLS.
+- **Now implemented offline:** **multi-epoch rotation** via `ReferenceAuthority` —
+  `Workspace::rotate_epoch` mints AMK_v{n+1} + a fresh write-tier key and admin-attests the new
+  epoch (assets imported before a rotation stay verifiable under their original epoch), plus a
+  serializable, admin-signed `SignedEpochLedger` (`to_ledger`/`from_ledger`, whose admin chain is
+  re-verified on reload; the local-only AMK-presence flag is restored out-of-band).
+- **Still deferred with OpenMLS:** membership add/remove, the `Welcome`/history-delivery flow,
+  and the album upgrade ceremony — these need live MLS group state, not just the epoch ledger.
 
 ### Hardware-bound key storage
 - Device keys are kept in a **software keystore** (private keys sealed under the

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -28,7 +28,8 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
   monotonic add-id counter; signed `SidecarV1` (schema as CBOR field 0); privacy-on-export.
 - **Backup** — deterministic signed tar artifact, AMK ledger, master-key escrow, Shamir
   2-of-3, and dry-run/commit restore with chain reconciliation.
-- **Lifecycle `Workspace`** — ties it together and is showcased end-to-end by `capsule demo`.
+- **Lifecycle `Workspace`** — ties it together and writes through to the queryable
+  `library.sqlite` index; showcased end-to-end by `capsule demo`.
 
 ## Deferred — with the seam in place
 
@@ -75,9 +76,14 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
 ### Other
 - Thumbnail/LQIP generation beyond `capsule-media`'s existing utilities.
 - Fusing the crypto data plane into the **existing plaintext import executor**
-  (`capsule_core::import::executor`): that pipeline still writes the legacy `AssetSidecar`.
-  The crypto-integrated lifecycle lives in `capsule_core::lifecycle::Workspace` (used by
-  `capsule demo`); unifying the two import paths is a follow-up.
+  (`capsule_core::import::executor`) — **partially done.** `capsule_core::lifecycle::Workspace`
+  now writes through to the shared `library.sqlite` index: every import / metadata edit /
+  soft-delete upserts the queryable `assets` row (+ user tags) and records a device-owned
+  `original` cache representation, so crypto-imported assets are timeline-queryable and feed the
+  Phase-3 cache sweep. Dedup against `assets` is consequently **global** across both import
+  paths. **Still deferred:** the legacy `import::executor` keeps writing the unsigned
+  `AssetSidecar`; replacing it with the signed `SidecarV1` + manifest + provenance path needs
+  the deferred thumbnail/LQIP (media) generation, so the full executor rewrite is a follow-up.
 
 ## How to see it working
 

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -59,11 +59,13 @@ complements the design docs in `capsule-docs/src/content/docs/design/`.
   refuse-by-default validation invariants those paths need are implemented in
   `capsule_core::validation` and ready to wire into `capsule-api`.
 - The **adaptive cache-eviction policy** (bounded budget, LRU-by-last-access retention of
-  recently-viewed blobs, tier-ordered eviction original → preview → thumbnail) is specified in
-  `capsule-docs` [Filesystem — Client → Space Recovery] but **not yet implemented** (issue #23,
-  scoped to documentation). Seam: last-access tracking lives in `capsule-core::db`
-  (`library.sqlite`) and the sweep in `capsule-core::library`, driven by `capsule-sdk`
-  connection-class detection — no core data-plane rework needed to land it.
+  recently-viewed blobs, tier-ordered eviction original → preview → thumbnail, pinned and
+  device-owned originals exempt) is **now implemented** (issue #23): the
+  `cached_representations` table + last-access tracking live in `capsule-core::db` and the sweep
+  `capsule_core::library::cache_sweep` deletes evicted cache files (never the canonical `media/`
+  files or the index). The byte budget is a plain parameter, so `capsule-sdk` connection-class
+  detection drives it unchanged. Still deferred upstream: that connection-class budget detection
+  and the wider networked server/client (HTTP/TUS, GraphQL, `/sync`, federation, peering).
 
 ### ML / AI
 - Embeddings, `sqlite-vec` vector search, the model registry, semantic/face features, and

--- a/capsule-core/src/crypto/authority/reference.rs
+++ b/capsule-core/src/crypto/authority/reference.rs
@@ -12,9 +12,9 @@
 //! - Minting an epoch sets the write-tier key and (optionally) the AMK presence **together**
 //!   — the design's "AMK epoch bump + write-tier rotation are one commit" atomicity.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::AlbumAuthority;
@@ -34,6 +34,32 @@ struct Entry {
     write_tier_pub: HybridVerifyingKey,
     admin_sig: HybridSignature,
     amk_present: bool,
+}
+
+/// The portable, admin-signed epoch ledger: every attested `(epoch, write_tier_pub)` with its
+/// admin signature. `amk_present` is **local-only** state and deliberately is *not* part of this
+/// signed artifact — on reload it is restored from the epochs a device actually holds AMKs for.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SignedEpochLedger {
+    /// Album this ledger speaks for.
+    pub album_id: Uuid,
+    /// The admin-tier public key every entry is signed under.
+    pub admin_pub: HybridVerifyingKey,
+    /// The attested epoch ceiling (must equal the max attested epoch).
+    pub ceiling: u32,
+    /// One entry per attested epoch.
+    pub entries: Vec<LedgerEntry>,
+}
+
+/// One epoch's signed attestation within a [`SignedEpochLedger`].
+#[derive(Clone, Serialize, Deserialize)]
+pub struct LedgerEntry {
+    /// Epoch number (`amk_version`).
+    pub epoch: u32,
+    /// The write-tier public key attested for this epoch.
+    pub write_tier_pub: HybridVerifyingKey,
+    /// The admin signature over `(album_id, epoch, write_tier_pub)`.
+    pub admin_sig: HybridSignature,
 }
 
 /// A reference album authority backed by an admin-signed epoch ledger.
@@ -115,6 +141,53 @@ impl ReferenceAuthority {
         if let Some(e) = self.entries.get_mut(&epoch.0) {
             e.amk_present = true;
         }
+    }
+
+    /// Export the admin-signed epoch ledger for persistence or transport. The local-only
+    /// AMK-presence flags are excluded — they are not part of the signed history.
+    pub fn to_ledger(&self) -> SignedEpochLedger {
+        SignedEpochLedger {
+            album_id: self.album_id,
+            admin_pub: self.admin_pub.clone(),
+            ceiling: self.ceiling.0,
+            entries: self
+                .entries
+                .iter()
+                .map(|(epoch, e)| LedgerEntry {
+                    epoch: *epoch,
+                    write_tier_pub: e.write_tier_pub.clone(),
+                    admin_sig: e.admin_sig.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Rebuild an authority from a serialized ledger, **re-verifying the entire admin chain**.
+    /// `held_epochs` are the epochs whose AMK content key this device actually holds, restoring
+    /// the local-only `amk_present` state. Returns `None` if the admin chain does not verify (a
+    /// tampered, forged, or rewound ledger).
+    pub fn from_ledger(ledger: &SignedEpochLedger, held_epochs: &BTreeSet<u32>) -> Option<Self> {
+        let entries = ledger
+            .entries
+            .iter()
+            .map(|le| {
+                (
+                    le.epoch,
+                    Entry {
+                        write_tier_pub: le.write_tier_pub.clone(),
+                        admin_sig: le.admin_sig.clone(),
+                        amk_present: held_epochs.contains(&le.epoch),
+                    },
+                )
+            })
+            .collect();
+        let authority = Self {
+            album_id: ledger.album_id,
+            admin_pub: ledger.admin_pub.clone(),
+            ceiling: AmkVersion(ledger.ceiling),
+            entries,
+        };
+        authority.admin_chain_verifies().then_some(authority)
     }
 }
 
@@ -251,5 +324,43 @@ mod tests {
         // Fabricate a higher ceiling than any attested epoch.
         auth.ceiling = AmkVersion(5);
         assert!(!auth.admin_chain_verifies());
+    }
+
+    #[test]
+    fn ledger_round_trip_reverifies_and_restores_amk_presence() {
+        let (album, admin, w1, w2) = setup();
+        let auth = ReferenceAuthority::new(album, admin.verifying_key())
+            .with_epoch(&admin, AmkVersion(1), &w1.verifying_key(), true)
+            .with_epoch(&admin, AmkVersion(2), &w2.verifying_key(), false);
+
+        // Serialize → canonical CBOR → deserialize preserves the ledger.
+        let bytes = cbor::to_canonical_vec(&auth.to_ledger()).unwrap();
+        let decoded: SignedEpochLedger = cbor::from_slice(&bytes).unwrap();
+
+        // Rebuild holding only epoch 1's AMK locally (presence is restored out-of-band).
+        let restored = ReferenceAuthority::from_ledger(&decoded, &BTreeSet::from([1])).unwrap();
+        assert!(restored.admin_chain_verifies());
+        assert_eq!(restored.epoch_ceiling(), AmkVersion(2));
+        assert_eq!(
+            restored.write_tier_pubkey(AmkVersion(2)),
+            Some(w2.verifying_key())
+        );
+        assert!(restored.has_amk(AmkVersion(1)));
+        assert!(!restored.has_amk(AmkVersion(2)));
+    }
+
+    #[test]
+    fn tampered_ledger_is_rejected_on_reload() {
+        let (album, admin, w1, w2) = setup();
+        let auth = ReferenceAuthority::new(album, admin.verifying_key()).with_epoch(
+            &admin,
+            AmkVersion(1),
+            &w1.verifying_key(),
+            true,
+        );
+        // Swap in a different write-tier key with no matching admin re-signature.
+        let mut ledger = auth.to_ledger();
+        ledger.entries[0].write_tier_pub = w2.verifying_key();
+        assert!(ReferenceAuthority::from_ledger(&ledger, &BTreeSet::from([1])).is_none());
     }
 }

--- a/capsule-core/src/db/driver.rs
+++ b/capsule-core/src/db/driver.rs
@@ -1,4 +1,4 @@
-use crate::db::rows::{AssetRow, AssetStackRow, StackMemberRow};
+use crate::db::rows::{AssetRow, AssetStackRow, CachedRepresentationRow, StackMemberRow};
 use crate::db::schema;
 use rusqlite::{Connection, params};
 use std::path::Path;
@@ -236,6 +236,80 @@ impl DatabaseDriver {
         let rows = stmt.query_map(params![threshold], map_asset_row)?;
         rows.collect()
     }
+
+    // ── Cached representations (adaptive cache eviction, issue #23) ──────────────
+
+    /// Insert or replace a cached representation row.
+    pub fn upsert_representation(
+        &self,
+        row: &CachedRepresentationRow,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO cached_representations
+             (uuid, tier, format, bytes, path, last_accessed_at, pinned, is_owned_original)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+            params![
+                row.uuid,
+                row.tier,
+                row.format,
+                row.bytes,
+                row.path,
+                row.last_accessed_at,
+                row.pinned as i64,
+                row.is_owned_original as i64,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Remove a cached representation row (after its file has been deleted).
+    pub fn remove_representation(&self, uuid: &str, tier: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "DELETE FROM cached_representations WHERE uuid = ?1 AND tier = ?2",
+            params![uuid, tier],
+        )?;
+        Ok(())
+    }
+
+    /// Stamp a representation's last-access time (recency promotion) — viewing an asset keeps its
+    /// representations from eviction. `now` is injected so the policy stays deterministic.
+    pub fn record_access(&self, uuid: &str, tier: &str, now: i64) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE cached_representations SET last_accessed_at = ?1 WHERE uuid = ?2 AND tier = ?3",
+            params![now, uuid, tier],
+        )?;
+        Ok(())
+    }
+
+    /// The reclaimable representations to evict so the reclaimable set fits within `budget_bytes`.
+    /// Pinned and device-owned originals are never candidates. Rows are ranked most-valuable-to-
+    /// keep first (most-recently-accessed; thumbnail over preview over original at equal recency),
+    /// then everything past the budget is evicted — i.e. least-recently-accessed first, original →
+    /// preview → thumbnail at equal recency.
+    pub fn eviction_candidates(
+        &self,
+        budget_bytes: i64,
+    ) -> Result<Vec<CachedRepresentationRow>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT uuid, tier, format, bytes, path, last_accessed_at, pinned, is_owned_original
+             FROM cached_representations
+             WHERE pinned = 0 AND is_owned_original = 0
+             ORDER BY last_accessed_at DESC,
+                      CASE tier WHEN 'thumbnail' THEN 2 WHEN 'preview' THEN 1 WHEN 'original' THEN 0 ELSE -1 END DESC",
+        )?;
+        let keep_first = stmt.query_map([], map_cached_representation_row)?;
+
+        let mut kept_bytes: i64 = 0;
+        let mut evict = Vec::new();
+        for row in keep_first {
+            let row = row?;
+            kept_bytes += row.bytes;
+            if kept_bytes > budget_bytes {
+                evict.push(row);
+            }
+        }
+        Ok(evict)
+    }
 }
 
 fn now_secs() -> i64 {
@@ -265,6 +339,21 @@ fn map_asset_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AssetRow> {
         rating: row.get(15)?,
         is_deleted: row.get::<_, i64>(16)? != 0,
         deleted_at: row.get(17)?,
+    })
+}
+
+fn map_cached_representation_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<CachedRepresentationRow> {
+    Ok(CachedRepresentationRow {
+        uuid: row.get(0)?,
+        tier: row.get(1)?,
+        format: row.get(2)?,
+        bytes: row.get(3)?,
+        path: row.get(4)?,
+        last_accessed_at: row.get(5)?,
+        pinned: row.get::<_, i64>(6)? != 0,
+        is_owned_original: row.get::<_, i64>(7)? != 0,
     })
 }
 
@@ -300,7 +389,7 @@ mod tests {
     fn test_init_schema_idempotent() {
         let db = DatabaseDriver::open_in_memory().unwrap();
         db.init_schema().unwrap(); // second call — should not fail
-        assert_eq!(db.schema_version().unwrap(), 1);
+        assert_eq!(db.schema_version().unwrap(), 2);
     }
 
     #[test]
@@ -421,5 +510,92 @@ mod tests {
         db.upsert_asset(&asset).unwrap();
         let found = db.find_by_hash(&"a".repeat(64)).unwrap().unwrap();
         assert_eq!(found.rating, 5);
+    }
+
+    fn rep(uuid: &str, tier: &str, bytes: i64, last: i64) -> CachedRepresentationRow {
+        CachedRepresentationRow {
+            uuid: uuid.to_string(),
+            tier: tier.to_string(),
+            format: None,
+            bytes,
+            path: format!("/cache/{uuid}.{tier}"),
+            last_accessed_at: last,
+            pinned: false,
+            is_owned_original: false,
+        }
+    }
+
+    fn evicted_ids(rows: &[CachedRepresentationRow]) -> Vec<&str> {
+        rows.iter().map(|r| r.uuid.as_str()).collect()
+    }
+
+    #[test]
+    fn eviction_is_least_recently_accessed_first() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        db.upsert_representation(&rep("a", "thumbnail", 100, 10))
+            .unwrap();
+        db.upsert_representation(&rep("b", "thumbnail", 100, 20))
+            .unwrap();
+        db.upsert_representation(&rep("c", "thumbnail", 100, 30))
+            .unwrap();
+        // 300 B reclaimable, budget 250 → evict only the least-recently-accessed.
+        let evicted = db.eviction_candidates(250).unwrap();
+        assert_eq!(evicted_ids(&evicted), ["a"]);
+    }
+
+    #[test]
+    fn eviction_tier_order_breaks_recency_ties() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        // Equal recency, three tiers — original (biggest, most regenerable) is evicted first.
+        db.upsert_representation(&rep("x", "original", 100, 50))
+            .unwrap();
+        db.upsert_representation(&rep("x", "preview", 100, 50))
+            .unwrap();
+        db.upsert_representation(&rep("x", "thumbnail", 100, 50))
+            .unwrap();
+        let evicted = db.eviction_candidates(250).unwrap();
+        assert_eq!(
+            evicted.iter().map(|r| r.tier.as_str()).collect::<Vec<_>>(),
+            ["original"]
+        );
+    }
+
+    #[test]
+    fn recency_promotion_protects_touched_representation() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        db.upsert_representation(&rep("a", "thumbnail", 100, 10))
+            .unwrap();
+        db.upsert_representation(&rep("b", "thumbnail", 100, 20))
+            .unwrap();
+        db.upsert_representation(&rep("c", "thumbnail", 100, 30))
+            .unwrap();
+        // Viewing the oldest makes it newest, so the next-oldest is evicted instead.
+        db.record_access("a", "thumbnail", 100).unwrap();
+        let evicted = db.eviction_candidates(250).unwrap();
+        assert_eq!(evicted_ids(&evicted), ["b"]);
+    }
+
+    #[test]
+    fn pinned_and_owned_originals_are_exempt() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        let mut pinned = rep("p", "original", 1000, 10);
+        pinned.pinned = true;
+        let mut owned = rep("o", "original", 1000, 10);
+        owned.is_owned_original = true;
+        db.upsert_representation(&pinned).unwrap();
+        db.upsert_representation(&owned).unwrap();
+        db.upsert_representation(&rep("c", "thumbnail", 100, 30))
+            .unwrap();
+        // Budget 0 reclaims everything reclaimable, but the exempt rows survive the sweep.
+        let evicted = db.eviction_candidates(0).unwrap();
+        assert_eq!(evicted_ids(&evicted), ["c"]);
+    }
+
+    #[test]
+    fn eviction_empty_when_within_budget() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        db.upsert_representation(&rep("a", "thumbnail", 100, 10))
+            .unwrap();
+        assert!(db.eviction_candidates(1000).unwrap().is_empty());
     }
 }

--- a/capsule-core/src/db/driver.rs
+++ b/capsule-core/src/db/driver.rs
@@ -310,6 +310,43 @@ impl DatabaseDriver {
         }
         Ok(evict)
     }
+
+    /// All cached representations recorded for `uuid` (any tier).
+    pub fn representations_for(
+        &self,
+        uuid: &str,
+    ) -> Result<Vec<CachedRepresentationRow>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT uuid, tier, format, bytes, path, last_accessed_at, pinned, is_owned_original
+             FROM cached_representations WHERE uuid = ?1 ORDER BY tier",
+        )?;
+        let rows = stmt.query_map(params![uuid], map_cached_representation_row)?;
+        rows.collect()
+    }
+
+    // ── User tags (asset_tags index) ────────────────────────────────────────────
+
+    /// Replace the indexed user tags for `uuid` with `tags` (the asset's current OR-set value).
+    pub fn replace_asset_tags(&self, uuid: &str, tags: &[String]) -> Result<(), rusqlite::Error> {
+        self.conn
+            .execute("DELETE FROM asset_tags WHERE uuid = ?1", params![uuid])?;
+        for tag in tags {
+            self.conn.execute(
+                "INSERT OR IGNORE INTO asset_tags (uuid, tag) VALUES (?1, ?2)",
+                params![uuid, tag],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// The indexed user tags for `uuid`, sorted.
+    pub fn tags_for(&self, uuid: &str) -> Result<Vec<String>, rusqlite::Error> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT tag FROM asset_tags WHERE uuid = ?1 ORDER BY tag")?;
+        let rows = stmt.query_map(params![uuid], |r| r.get::<_, String>(0))?;
+        rows.collect()
+    }
 }
 
 fn now_secs() -> i64 {

--- a/capsule-core/src/db/mod.rs
+++ b/capsule-core/src/db/mod.rs
@@ -3,4 +3,4 @@ pub mod rows;
 pub mod schema;
 
 pub use driver::DatabaseDriver;
-pub use rows::{AssetRow, AssetStackRow, AssetTagRow, StackMemberRow};
+pub use rows::{AssetRow, AssetStackRow, AssetTagRow, CachedRepresentationRow, StackMemberRow};

--- a/capsule-core/src/db/rows.rs
+++ b/capsule-core/src/db/rows.rs
@@ -47,3 +47,20 @@ pub struct AssetTagRow {
     pub uuid: String,
     pub tag: String,
 }
+
+/// One cached, reclaimable representation of an asset. The eviction sweep ranks these by
+/// `last_accessed_at` (LRU) with `tier` as the tiebreaker; `pinned` and `is_owned_original`
+/// rows are exempt. `path` is the on-disk cache file the sweep deletes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CachedRepresentationRow {
+    pub uuid: String,
+    /// `"original"` | `"preview"` | `"thumbnail"`.
+    pub tier: String,
+    pub format: Option<String>,
+    pub bytes: i64,
+    pub path: String,
+    pub last_accessed_at: i64,
+    pub pinned: bool,
+    /// An original this device itself owns as source of truth — never auto-evicted.
+    pub is_owned_original: bool,
+}

--- a/capsule-core/src/db/schema.rs
+++ b/capsule-core/src/db/schema.rs
@@ -1,4 +1,4 @@
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 pub const DDL: &str = r#"
 PRAGMA journal_mode = WAL;
@@ -62,4 +62,24 @@ CREATE INDEX IF NOT EXISTS idx_stacks_primary    ON asset_stacks(primary_asset_i
 CREATE INDEX IF NOT EXISTS idx_stack_members_stack  ON stack_members(stack_id);
 CREATE INDEX IF NOT EXISTS idx_stack_members_asset  ON stack_members(asset_id);
 CREATE INDEX IF NOT EXISTS idx_tags_tag          ON asset_tags(tag);
+
+-- Reclaimable cached representations of an asset (the cache/ tier — thumbnails, previews,
+-- transcodes — plus fetched-but-unpinned originals). Eviction is LRU by last_accessed_at,
+-- tier original → preview → thumbnail at equal recency; pinned and device-owned originals are
+-- exempt. Authoritative local state (re-scannable from disk), untouched by index rebuild.
+-- SSoT: design/filesystem/client § Space Recovery.
+CREATE TABLE IF NOT EXISTS cached_representations (
+    uuid              TEXT    NOT NULL,
+    tier              TEXT    NOT NULL,
+    format            TEXT,
+    bytes             INTEGER NOT NULL,
+    path              TEXT    NOT NULL,
+    last_accessed_at  INTEGER NOT NULL,
+    pinned            INTEGER NOT NULL DEFAULT 0,
+    is_owned_original INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (uuid, tier)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cache_evict
+    ON cached_representations(pinned, is_owned_original, last_accessed_at);
 "#;

--- a/capsule-core/src/library/cache.rs
+++ b/capsule-core/src/library/cache.rs
@@ -1,0 +1,104 @@
+//! Adaptive cache eviction — the client-side "Space Recovery" sweep.
+//!
+//! Keeps the reclaimable cache (the `cache/` tree plus fetched-but-unpinned originals) within a
+//! byte budget by evicting least-recently-accessed representations first, with tier order
+//! (original → preview → thumbnail) breaking recency ties. Pinned representations, device-owned
+//! originals, the canonical `media/` files, and the `library.sqlite` index are never touched.
+//! The budget is a plain parameter so `capsule-sdk` connection-class detection can drive it.
+//!
+//! SSoT: design/filesystem/client § Space Recovery.
+
+use std::fs;
+use std::path::Path;
+
+use crate::db::DatabaseDriver;
+use crate::db::rows::CachedRepresentationRow;
+
+/// What an eviction sweep reclaimed.
+#[derive(Debug, Default, PartialEq)]
+pub struct EvictionReport {
+    /// The representations evicted, worst-first (least-recently-accessed).
+    pub evicted: Vec<CachedRepresentationRow>,
+    /// Total bytes reclaimed.
+    pub bytes_reclaimed: i64,
+}
+
+/// Reclaim cached representations until the reclaimable set fits within `budget_bytes`. Deletes
+/// each evicted representation's cache file from disk and removes its index row. A cache file that
+/// is already gone is treated as reclaimed (not an error) and its stale row is still dropped.
+/// Pinned and device-owned originals are never evicted by this automatic path; canonical `media/`
+/// files are never candidates (they are not tracked in `cached_representations`).
+pub fn cache_sweep(
+    db: &DatabaseDriver,
+    budget_bytes: i64,
+) -> Result<EvictionReport, rusqlite::Error> {
+    let candidates = db.eviction_candidates(budget_bytes)?;
+    let mut report = EvictionReport::default();
+    for row in candidates {
+        let _ = fs::remove_file(Path::new(&row.path));
+        db.remove_representation(&row.uuid, &row.tier)?;
+        report.bytes_reclaimed += row.bytes;
+        report.evicted.push(row);
+    }
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn sweep_deletes_cache_files_and_rows_but_not_canonical_media() {
+        let dir = TempDir::new().unwrap();
+        let db = DatabaseDriver::open_in_memory().unwrap();
+
+        // A reclaimable thumbnail file and a canonical media file that must survive.
+        let thumb = dir.path().join("thumb.jpg");
+        let canonical = dir.path().join("original.jpg");
+        fs::write(&thumb, vec![0u8; 500]).unwrap();
+        fs::write(&canonical, b"canonical bytes").unwrap();
+
+        db.upsert_representation(&CachedRepresentationRow {
+            uuid: "a".to_string(),
+            tier: "thumbnail".to_string(),
+            format: Some("jpg".to_string()),
+            bytes: 500,
+            path: thumb.to_string_lossy().into_owned(),
+            last_accessed_at: 1,
+            pinned: false,
+            is_owned_original: false,
+        })
+        .unwrap();
+
+        // Budget 0 → reclaim everything reclaimable.
+        let report = cache_sweep(&db, 0).unwrap();
+        assert_eq!(report.evicted.len(), 1);
+        assert_eq!(report.bytes_reclaimed, 500);
+        assert!(!thumb.exists(), "evicted cache file is deleted");
+        assert!(canonical.exists(), "canonical media is untouched");
+        assert!(
+            db.eviction_candidates(0).unwrap().is_empty(),
+            "the index row is removed"
+        );
+    }
+
+    #[test]
+    fn sweep_missing_file_is_not_an_error() {
+        let db = DatabaseDriver::open_in_memory().unwrap();
+        db.upsert_representation(&CachedRepresentationRow {
+            uuid: "gone".to_string(),
+            tier: "preview".to_string(),
+            format: None,
+            bytes: 10,
+            path: "/nonexistent/path/preview.bin".to_string(),
+            last_accessed_at: 1,
+            pinned: false,
+            is_owned_original: false,
+        })
+        .unwrap();
+        let report = cache_sweep(&db, 0).unwrap();
+        assert_eq!(report.evicted.len(), 1);
+        assert!(db.eviction_candidates(0).unwrap().is_empty());
+    }
+}

--- a/capsule-core/src/library/init.rs
+++ b/capsule-core/src/library/init.rs
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(ver.version, CURRENT_LIBRARY_VERSION);
 
         // SQLite has the correct schema version
-        assert_eq!(lib.db.schema_version().unwrap(), 1);
+        assert_eq!(lib.db.schema_version().unwrap(), 2);
 
         // Config has the correct library name
         assert_eq!(lib.config().library_name, "My Library");

--- a/capsule-core/src/library/mod.rs
+++ b/capsule-core/src/library/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod error;
 pub mod init;
 #[allow(clippy::module_inception)]
@@ -9,6 +10,7 @@ pub mod rebuild;
 pub mod scrub;
 pub mod trash;
 
+pub use cache::{EvictionReport, cache_sweep};
 pub use error::LibraryError;
 pub use init::init_library;
 pub use library::Library;

--- a/capsule-core/src/lifecycle.rs
+++ b/capsule-core/src/lifecycle.rs
@@ -17,8 +17,9 @@
 //!   regenerated deterministically from the manifest's recorded nonce prefix.
 //!
 //! Clients store **plaintext** locally (original + signed sidecar + provenance chain);
-//! encryption produces the artifacts that cross a boundary. Album epoch rotation (the MLS
-//! ceremony) is deferred — albums here are single-epoch (see `DEFERRED.md`).
+//! encryption produces the artifacts that cross a boundary. Offline epoch rotation is supported
+//! ([`rotate_epoch`](Workspace::rotate_epoch)); the MLS membership ceremony (`Welcome`,
+//! add/remove) remains deferred (see `DEFERRED.md`).
 //!
 //! [`verify_asset`]: crate::crypto::verify_asset
 
@@ -73,7 +74,7 @@ pub enum LifecycleError {
 
 type Result<T> = std::result::Result<T, LifecycleError>;
 
-/// One album's key material (single-epoch in this offline core).
+/// One album's key material across one or more epochs.
 pub struct AlbumKeys {
     /// Album id.
     pub album_id: Uuid,
@@ -85,7 +86,7 @@ pub struct AlbumKeys {
     pub write_tier: HybridSigningKey,
     /// Per-album admin signing key.
     pub admin: HybridSigningKey,
-    /// The current (and only) epoch.
+    /// The current (highest) epoch — the one new imports are written under.
     pub current_epoch: u32,
 }
 
@@ -239,6 +240,39 @@ impl Workspace {
         album_id
     }
 
+    /// Rotate `album_id` to a fresh epoch: mint AMK_v{n+1} and a new write-tier key, have the
+    /// album admin attest the new epoch, and advance the current epoch — the design's
+    /// "AMK bump + write-tier rotation are one commit" atomicity. The admin key (the ledger
+    /// root) is stable across epochs, and existing assets stay verifiable under their original
+    /// epoch. Returns the new epoch. Membership changes / the MLS `Welcome` flow remain deferred
+    /// (see `DEFERRED.md`).
+    pub fn rotate_epoch(&mut self, album_id: Uuid) -> Result<u32> {
+        let next = {
+            let album = self
+                .albums
+                .get_mut(&album_id)
+                .ok_or_else(|| LifecycleError::NotFound(format!("album {album_id}")))?;
+            let next = album.current_epoch + 1;
+            album.amks.insert(next, *Amk::generate().as_bytes());
+            album.write_tier = HybridSigningKey::generate();
+            album.current_epoch = next;
+            next
+        };
+        // Disjoint fields: read the album's keys while mutably attesting in its authority.
+        let album = self.albums.get(&album_id).expect("album just mutated");
+        let authority = self
+            .authorities
+            .get_mut(&album_id)
+            .ok_or_else(|| LifecycleError::NotFound(format!("authority {album_id}")))?;
+        authority.attest_epoch(
+            &album.admin,
+            AmkVersion(next),
+            &album.write_tier.verifying_key(),
+            true,
+        );
+        Ok(next)
+    }
+
     fn album(&self, album_id: &Uuid) -> Result<&AlbumKeys> {
         self.albums
             .get(album_id)
@@ -260,8 +294,11 @@ impl Workspace {
         ))
     }
 
-    fn file_key(&self, album: &AlbumKeys, file_id: &Uuid) -> [u8; 32] {
-        let amk = Amk::from_bytes(album.amks[&album.current_epoch]);
+    /// Derive the per-file key under a *specific* epoch's AMK. Callers pass the epoch the asset
+    /// was written under (`amk_version`), never assuming the album's current epoch — so an asset
+    /// imported before a rotation still derives the key it was encrypted with.
+    fn file_key(&self, album: &AlbumKeys, epoch: u32, file_id: &Uuid) -> [u8; 32] {
+        let amk = Amk::from_bytes(album.amks[&epoch]);
         amk.derive_file_key(file_id)
     }
 
@@ -312,7 +349,7 @@ impl Workspace {
         let capture_utc = Utc::now().timestamp();
 
         let album = self.album(&album_id)?;
-        let file_key = self.file_key(album, &asset_id);
+        let file_key = self.file_key(album, album.current_epoch, &asset_id);
         let (enc, ciphertext) = stream::encrypt_asset_vec_full(&file_key, &plaintext);
 
         let core = ManifestCore {
@@ -401,7 +438,7 @@ impl Workspace {
         let head = &asset.chain.records().last().unwrap().manifest;
         let plaintext =
             fs::read(self.media_path(asset)).map_err(|e| LifecycleError::Io(e.to_string()))?;
-        let file_key = self.file_key(album, &head.core.file_id);
+        let file_key = self.file_key(album, head.core.amk_version.0, &head.core.file_id);
         let (_, ciphertext) =
             stream::encrypt_asset_vec_with_prefix(&file_key, head.core.nonce_prefix, &plaintext);
 
@@ -517,21 +554,19 @@ impl Workspace {
             let head = &asset.chain.records().last().unwrap().manifest;
             let plaintext =
                 fs::read(self.media_path(asset)).map_err(|e| LifecycleError::Io(e.to_string()))?;
-            let file_key = self.file_key(album, &head.core.file_id);
+            let epoch = head.core.amk_version.0;
+            let file_key = self.file_key(album, epoch, &head.core.file_id);
             let (_, ciphertext) = stream::encrypt_asset_vec_with_prefix(
                 &file_key,
                 head.core.nonce_prefix,
                 &plaintext,
             );
-            let amk = Amk::from_bytes(album.amks[&album.current_epoch]);
+            let amk = Amk::from_bytes(album.amks[&epoch]);
             let metadata_blob = seal_blob(
                 &amk.derive_blob_key(&asset.asset_id),
                 &asset.sidecar.to_canonical_vec(),
             );
-            amks.insert(
-                (asset.album_id, head.core.amk_version.0),
-                album.amks[&album.current_epoch],
-            );
+            amks.insert((asset.album_id, epoch), album.amks[&epoch]);
             assets.push(BackupAsset {
                 album_id: asset.album_id,
                 asset_id: asset.asset_id,
@@ -756,6 +791,59 @@ mod tests {
         assert!(
             ws3.import_backup(&backup_path, b"recovery-pass", &imposter)
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn epoch_rotation_keeps_old_assets_verifiable_and_backs_up() {
+        let lib = TempDir::new().unwrap();
+        let src = TempDir::new().unwrap();
+        let a = src.path().join("a.jpg");
+        let b = src.path().join("b.jpg");
+        fs::write(&a, b"\xFF\xD8\xFF first photo, written at epoch 1").unwrap();
+        fs::write(&b, b"\xFF\xD8\xFF second photo, written at epoch 2").unwrap();
+
+        let mut ws = fast_workspace(lib.path());
+        let album = ws.create_album("Trip");
+
+        // Import at epoch 1, rotate the album, import at epoch 2.
+        let id_a = ws.import_asset(album, &a).unwrap();
+        assert_eq!(ws.rotate_epoch(album).unwrap(), 2);
+        let id_b = ws.import_asset(album, &b).unwrap();
+
+        // Each asset recorded the epoch it was written under...
+        let epoch_of = |ws: &Workspace, id| {
+            ws.asset(id).unwrap().chain.records()[0]
+                .manifest
+                .core
+                .amk_version
+        };
+        assert_eq!(epoch_of(&ws, &id_a), AmkVersion(1));
+        assert_eq!(epoch_of(&ws, &id_b), AmkVersion(2));
+        // ...and BOTH still verify — the pre-rotation asset under its original epoch key (the
+        // regression guard for the `current_epoch` file-key bug).
+        assert_eq!(ws.verify(&id_a).unwrap(), VerifyOutcome::Accept);
+        assert_eq!(ws.verify(&id_b).unwrap(), VerifyOutcome::Accept);
+
+        // A cross-epoch backup escrows each asset's own-epoch AMK; restore into a fresh library
+        // is byte-equal for both (guards the export file-key / blob-key / escrow-value epochs).
+        let backup_path = src.path().join("backup.tar");
+        ws.export_backup(&backup_path, b"recovery-pass").unwrap();
+        let exporter_pub = ws.exporter_verifying_key();
+
+        let fresh = TempDir::new().unwrap();
+        let mut ws2 = fast_workspace(fresh.path());
+        let added = ws2
+            .import_backup(&backup_path, b"recovery-pass", &exporter_pub)
+            .unwrap();
+        assert_eq!(added, 2);
+        assert_eq!(
+            ws2.read_plaintext(&id_a).unwrap(),
+            ws.read_plaintext(&id_a).unwrap()
+        );
+        assert_eq!(
+            ws2.read_plaintext(&id_b).unwrap(),
+            ws.read_plaintext(&id_b).unwrap()
         );
     }
 }

--- a/capsule-core/src/lifecycle.rs
+++ b/capsule-core/src/lifecycle.rs
@@ -43,6 +43,8 @@ use crate::crypto::provenance::manifest::{ASSET_MANIFEST_VERSION, ManifestCore};
 use crate::crypto::provenance::{AssetManifest, ProvenanceChain, ProvenanceRecord};
 use crate::crypto::verify_asset::{VerifyOutcome, verify_asset};
 use crate::crypto::{CryptoError, authority::ReferenceAuthority};
+use crate::db::{AssetRow, CachedRepresentationRow, DatabaseDriver};
+use crate::library::Library;
 use crate::metadata::crdt::{AddId, Counter};
 use crate::sidecar::sidecar_v1::{SIDECAR_SCHEMA_V1, SidecarV1};
 
@@ -70,6 +72,9 @@ pub enum LifecycleError {
     /// CBOR (de)serialization error.
     #[error("cbor: {0}")]
     Cbor(String),
+    /// Library index (SQLite) error.
+    #[error("db: {0}")]
+    Db(String),
 }
 
 type Result<T> = std::result::Result<T, LifecycleError>;
@@ -115,6 +120,9 @@ pub struct Workspace {
     albums: HashMap<Uuid, AlbumKeys>,
     authorities: HashMap<Uuid, ReferenceAuthority>,
     assets: HashMap<Uuid, AssetState>,
+    /// The open, locked library — its `library.sqlite` is the queryable index the crypto
+    /// lifecycle writes through to. Held for the workspace's lifetime so the lock is retained.
+    library: Library,
 }
 
 fn now_rfc3339() -> String {
@@ -140,6 +148,62 @@ fn media_dir(root: &Path, capture_utc: i64) -> PathBuf {
         .join(format!("{:04}-{:02}", dt.year(), dt.month()))
 }
 
+fn asset_type_for(content_type: &str) -> String {
+    if content_type.starts_with("video/") {
+        "video"
+    } else {
+        "photo"
+    }
+    .to_string()
+}
+
+fn rfc3339_to_secs(s: &str) -> i64 {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .map(|d| d.timestamp())
+        .unwrap_or(0)
+}
+
+/// Map a managed asset's in-memory state to its queryable `assets` index row. Deletion state is
+/// derived from the provenance chain's lifecycle actions; media-derived fields (dimensions,
+/// duration, chromahash) stay NULL — they are out of scope in this offline core.
+fn asset_row_from_state(asset: &AssetState) -> AssetRow {
+    let mut is_deleted = false;
+    let mut deleted_at = None;
+    for rec in asset.chain.records() {
+        match rec.manifest.core.action {
+            Action::Delete => {
+                is_deleted = true;
+                deleted_at = Some(rfc3339_to_secs(&rec.manifest.core.timestamp));
+            }
+            Action::TrashRestore => {
+                is_deleted = false;
+                deleted_at = None;
+            }
+            _ => {}
+        }
+    }
+    AssetRow {
+        uuid: asset.asset_id.to_string(),
+        asset_type: asset_type_for(&asset.sidecar.content_type),
+        capture_timestamp: asset.capture_utc,
+        capture_utc: Some(asset.capture_utc),
+        capture_tz_source: None,
+        import_timestamp: rfc3339_to_secs(&asset.sidecar.import_timestamp),
+        hash_sha256: asset.sidecar.hash.to_hex(),
+        width: asset.sidecar.dimensions.as_ref().map(|d| d.width as i64),
+        height: asset.sidecar.dimensions.as_ref().map(|d| d.height as i64),
+        duration_ms: None,
+        stack_id: None,
+        is_stack_hidden: false,
+        chromahash: None,
+        dominant_color: None,
+        album_id: Some(asset.album_id.to_string()),
+        rating: asset.sidecar.rating.get().copied().unwrap_or(0) as i64,
+        is_deleted,
+        deleted_at,
+    }
+}
+
 impl Workspace {
     /// Create a fresh workspace: initialise the library directory and a new account, and
     /// publish a device directory. `passphrase` guards the on-disk account; `tier` sets the
@@ -158,7 +222,7 @@ impl Workspace {
         passphrase: &[u8],
         params: crate::crypto::primitives::Argon2Params,
     ) -> Result<Self> {
-        crate::library::init::init_library(root, "Capsule")
+        let library = crate::library::init::init_library(root, "Capsule")
             .map_err(|e| LifecycleError::Io(format!("init library: {e}")))?;
         let account = Account::create();
         let file = account.to_file_with(passphrase, params)?;
@@ -177,6 +241,7 @@ impl Workspace {
             albums: HashMap::new(),
             authorities: HashMap::new(),
             assets: HashMap::new(),
+            library,
         })
     }
 
@@ -336,6 +401,40 @@ impl Workspace {
         Ok(())
     }
 
+    /// Write the queryable index row + user tags for `asset` into `library.sqlite`. Re-syncs on
+    /// every change (import, metadata edit, soft-delete/restore), so the index reflects the
+    /// asset's current rating, tags, and deletion state. Upsert keeps it conflict-safe even
+    /// though the legacy importer shares the same `assets` table.
+    fn index_asset_row(&self, asset: &AssetState) -> Result<()> {
+        self.library
+            .db
+            .upsert_asset(&asset_row_from_state(asset))
+            .map_err(|e| LifecycleError::Db(e.to_string()))?;
+        let tags: Vec<String> = asset.sidecar.tags_user.value().into_iter().collect();
+        self.library
+            .db
+            .replace_asset_tags(&asset.asset_id.to_string(), &tags)
+            .map_err(|e| LifecycleError::Db(e.to_string()))
+    }
+
+    /// Record the asset's own original as a device-owned cache representation — exempt from the
+    /// automatic eviction sweep, and the real lifecycle data that sweep then operates on.
+    fn index_original_representation(&self, asset: &AssetState, bytes: usize) -> Result<()> {
+        self.library
+            .db
+            .upsert_representation(&CachedRepresentationRow {
+                uuid: asset.asset_id.to_string(),
+                tier: "original".to_string(),
+                format: Some(asset.ext.clone()),
+                bytes: bytes as i64,
+                path: self.media_path(asset).to_string_lossy().into_owned(),
+                last_accessed_at: Utc::now().timestamp(),
+                pinned: false,
+                is_owned_original: true,
+            })
+            .map_err(|e| LifecycleError::Db(e.to_string()))
+    }
+
     /// Import a file into `album_id`: encrypt, build the signed create manifest + provenance,
     /// write the signed sidecar, and self-verify through `verify_asset`. Returns the asset id.
     pub fn import_asset(&mut self, album_id: Uuid, src: &Path) -> Result<Uuid> {
@@ -424,6 +523,8 @@ impl Workspace {
             sidecar,
         };
         self.write_asset_files(&asset, &plaintext)?;
+        self.index_asset_row(&asset)?;
+        self.index_original_representation(&asset, plaintext.len())?;
         self.assets.insert(asset_id, asset);
         Ok(asset_id)
     }
@@ -504,7 +605,8 @@ impl Workspace {
         let asset = self.assets.get(asset_id).unwrap();
         let plaintext =
             fs::read(self.media_path(asset)).map_err(|e| LifecycleError::Io(e.to_string()))?;
-        self.write_asset_files(asset, &plaintext)
+        self.write_asset_files(asset, &plaintext)?;
+        self.index_asset_row(asset)
     }
 
     /// Add a user tag (OR-set) and emit a `metadata-update` provenance record.
@@ -630,6 +732,8 @@ impl Workspace {
                 sidecar,
             };
             self.write_asset_files(&asset, &restored.plaintext)?;
+            self.index_asset_row(&asset)?;
+            self.index_original_representation(&asset, restored.plaintext.len())?;
             self.assets.insert(restored.asset_id, asset);
             added += 1;
         }
@@ -688,6 +792,12 @@ impl Workspace {
     /// A managed asset's current state.
     pub fn asset(&self, asset_id: &Uuid) -> Option<&AssetState> {
         self.assets.get(asset_id)
+    }
+
+    /// The library's queryable SQLite index — the timeline, user tags, and cached representations
+    /// the crypto lifecycle writes through to.
+    pub fn db(&self) -> &DatabaseDriver {
+        &self.library.db
     }
 }
 
@@ -845,5 +955,51 @@ mod tests {
             ws2.read_plaintext(&id_b).unwrap(),
             ws.read_plaintext(&id_b).unwrap()
         );
+    }
+
+    #[test]
+    fn crypto_lifecycle_writes_through_to_the_index() {
+        let lib = TempDir::new().unwrap();
+        let src = TempDir::new().unwrap();
+        let img = src.path().join("photo.jpg");
+        fs::write(&img, b"\xFF\xD8\xFF indexed photo").unwrap();
+
+        let mut ws = fast_workspace(lib.path());
+        let album = ws.create_album("Trip");
+        let id = ws.import_asset(album, &img).unwrap();
+        let uuid = id.to_string();
+
+        // The import is queryable in the timeline, tagged to its album.
+        let timeline = ws.db().query_timeline(0, 100).unwrap();
+        assert_eq!(timeline.len(), 1);
+        assert_eq!(timeline[0].uuid, uuid);
+        assert_eq!(
+            timeline[0].album_id.as_deref(),
+            Some(album.to_string().as_str())
+        );
+
+        // It recorded a device-owned `original` representation, exempt from eviction.
+        let reps = ws.db().representations_for(&uuid).unwrap();
+        assert_eq!(reps.len(), 1);
+        assert_eq!(reps[0].tier, "original");
+        assert!(reps[0].is_owned_original);
+        assert!(
+            ws.db().eviction_candidates(0).unwrap().is_empty(),
+            "an owned original is never an eviction candidate"
+        );
+
+        // A tag edit re-syncs into the index.
+        ws.tag_add(&id, "vacation").unwrap();
+        assert_eq!(
+            ws.db().tags_for(&uuid).unwrap(),
+            vec!["vacation".to_string()]
+        );
+
+        // Soft-delete hides it from the timeline; restore brings it back (deletion state is
+        // derived from the provenance chain).
+        ws.soft_delete(&id, 30).unwrap();
+        assert!(ws.db().query_timeline(0, 100).unwrap().is_empty());
+        ws.restore(&id).unwrap();
+        assert_eq!(ws.db().query_timeline(0, 100).unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
**Stack: PR 4 of 4** (top) — base is `feat/cache-eviction` (PR 3). Review last.

## What & why
`Workspace::import_asset` wrote media/sidecar/provenance to disk but never the `library.sqlite` index — the crypto lifecycle and the `db`/`Library` layer were disjoint. This PR bridges them: the **media-free slice of import unification**. Crypto-imported assets become timeline-queryable and give the Phase-3 cache sweep real lifecycle data to operate on. The legacy `import::executor` is left as-is (its full crypto rewrite needs the deferred thumbnail/LQIP media work).

## Changes
- **`Workspace` owns the `Library`** — binds the handle `init_library` returns instead of dropping it (previously the process lock was acquired and immediately released). The lock is now held for the workspace's lifetime.
- **Write-through on every change** — import / metadata edit / soft-delete / restore upsert the queryable `assets` row + user tags. `asset_row_from_state` derives deletion state from the provenance chain (so soft-delete/restore reflect correctly). Import also records a **device-owned `original`** cache representation, which the Phase-3 sweep sees and never evicts.
- New `DatabaseDriver` helpers: `representations_for`, `replace_asset_tags`, `tags_for`; `Workspace::db()` exposes the index for queries.

## ⚠️ Decision flagged for review
This fuses the crypto lifecycle and the legacy importer onto **one `assets` table**, so `find_by_hash` **dedup is now global** across both import paths. That's arguably correct (dedup *should* be global), but it is a behavior change to the legacy path. It's implemented conservatively — `upsert_asset` (INSERT OR REPLACE) is PK-conflict-safe, and the two paths' tests use separate `TempDir`s so they don't collide.

## Out of scope (still deferred)
- **Cross-process `Workspace::open`** — album keys (AMKs / write-tier / admin) aren't persisted yet, so a Workspace can't be reopened across processes regardless of indexing. The index still persists on disk for external readers.
- The **legacy executor rewrite** (needs media/thumbnails).

## Validation
- import → `query_timeline` returns the asset with a device-owned `original` representation; tag edit → `tags_for` reflects; `soft_delete` hides it, `restore` brings it back
- `cargo test --workspace --exclude capsule-sdk` green; `cargo clippy -p capsule-core -- -D warnings` green; **`capsule demo` runs end-to-end** (byte-equal restore)

> Same pre-existing macOS-only `unused_mut` caveat in `capsule-api-upload` as the rest of the stack (clean on Linux CI).