### PR TITLE
Cross-compilation targets & CI [1/3 hardware-bound key storage]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              - 'Cross.toml'
+              - 'justfile'
+              - '.cargo/**'
               - 'capsule-api/**'
               - 'capsule-cli/**'
               - 'capsule-core/**'
@@ -93,6 +96,74 @@ jobs:
         uses: extractions/setup-just@v3
       - name: Test
         run: just test-rust
+
+  # Verify capsule-core cross-compiles to the formally supported targets (mobile +
+  # desktop). Tier 1 (Apple, Android) gates; Tier 2 (Windows MSVC, aarch64 Linux)
+  # is best-effort via continue-on-error. The host x86_64 Linux Tier-1 target is
+  # already covered by the `rust` job's workspace build.
+  rust-cross:
+    name: Rust cross (${{ matrix.name }})
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.tier2 }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: apple
+            os: macos-14
+            recipe: build-apple
+            targets: aarch64-apple-darwin x86_64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+            tier2: false
+          - name: android
+            os: ubuntu-latest
+            recipe: build-android
+            targets: aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+            tier2: false
+          - name: windows
+            os: windows-latest
+            recipe: build-windows
+            targets: x86_64-pc-windows-msvc
+            tier2: true
+          - name: linux-arm64
+            os: ubuntu-latest
+            recipe: build-linux-cross
+            targets: aarch64-unknown-linux-gnu
+            tier2: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install
+          rustup target add ${{ matrix.targets }}
+      - name: Set up Android NDK
+        if: matrix.name == 'android'
+        id: ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27c
+      - name: Export ANDROID_NDK_HOME
+        if: matrix.name == 'android' && steps.ndk.outputs.ndk-path != ''
+        run: echo "ANDROID_NDK_HOME=${{ steps.ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+      - name: Install cargo-ndk
+        if: matrix.name == 'android'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
+      - name: Install cross
+        if: matrix.name == 'linux-arm64'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: cross-${{ matrix.name }}
+      - name: Install just
+        uses: extractions/setup-just@v3
+      - name: Build target
+        run: just ${{ matrix.recipe }}
 
   web:
     name: Web (format + lint + test + build)
@@ -170,12 +241,13 @@ jobs:
   required:
     name: required
     if: always()
-    needs: [changes, rust, rust-test, web, docs, vision]
+    needs: [changes, rust, rust-test, rust-cross, web, docs, vision]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs succeeded
         run: |
-          for r in "${{ needs.rust.result }}" "${{ needs.web.result }}" \
+          for r in "${{ needs.rust.result }}" "${{ needs.rust-cross.result }}" \
+                   "${{ needs.web.result }}" \
                    "${{ needs.docs.result }}" "${{ needs.vision.result }}"; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
               echo "A required job did not pass (result: $r)."

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+# `cross` (cross-rs) configuration for the Tier-2, best-effort aarch64 Linux
+# target. Apple targets cannot use cross (they need macOS + Xcode) and Android
+# uses cargo-ndk — see the justfile `build-*` recipes. The default cross image
+# already ships the gcc cross-toolchain that rusqlite's `bundled` SQLite (C) and
+# the RustCrypto stack need, so no extra packages are required; we only pin the
+# image tag for reproducibility.
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5"

--- a/capsule-core/Cargo.toml
+++ b/capsule-core/Cargo.toml
@@ -4,6 +4,13 @@ version.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lib]
+# `lib` (rlib) keeps the rest of the workspace linking capsule-core unchanged.
+# `cdylib` is the Android `.so` and `staticlib` the iOS XCFramework input for the
+# uniffi bindings (see the `ffi` feature). Cargo cannot gate crate-type by feature,
+# so host builds also emit these artifacts — an accepted, cheap cost.
+crate-type = ["lib", "cdylib", "staticlib"]
+
 [dependencies]
 chrono = { workspace = true }
 ciborium = "0.2"

--- a/justfile
+++ b/justfile
@@ -94,9 +94,11 @@ build-rust:
 #   Tier 2 — best-effort (build-only, non-blocking):
 #     x86_64-pc-windows-msvc        aarch64-unknown-linux-gnu
 #
-# Apple builds natively on macOS; Android via cargo-ndk; aarch64 Linux via
-# `cross` (none can build Apple). The build-* recipes self-skip when their
-# toolchain/OS is absent, so `build-targets` is safe to run anywhere.
+# Apple builds natively on macOS; Android via cargo-ndk; aarch64 Linux via `cross`
+# (none can build Apple). build-apple skips off-macOS — a platform constraint, not a
+# fixable dependency. build-android / build-linux-cross instead FAIL when their
+# toolchain is missing, so a silent skip never masks an un-built target; install the
+# toolchains (`just targets-add`, an Android NDK, `cross`) before `build-targets`.
 
 [group('rust')]
 targets-add:
@@ -120,15 +122,15 @@ build-apple:
 build-android:
     #!/usr/bin/env bash
     set -euo pipefail
-    if ! command -v cargo-ndk >/dev/null 2>&1; then echo "Skipping Android (cargo-ndk missing; run 'just targets-add')"; exit 0; fi
-    if [ -z "${ANDROID_NDK_HOME:-}${ANDROID_NDK_ROOT:-}" ]; then echo "Skipping Android (ANDROID_NDK_HOME unset)"; exit 0; fi
+    if ! command -v cargo-ndk >/dev/null 2>&1; then echo "build-android: cargo-ndk missing; run 'just targets-add'" >&2; exit 1; fi
+    if [ -z "${ANDROID_NDK_HOME:-}${ANDROID_NDK_ROOT:-}" ]; then echo "build-android: set ANDROID_NDK_HOME (or ANDROID_NDK_ROOT) to your Android NDK" >&2; exit 1; fi
     cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 --platform 26 build -p capsule-core
 
 [group('rust')]
 build-linux-cross:
     #!/usr/bin/env bash
     set -euo pipefail
-    if ! command -v cross >/dev/null 2>&1; then echo "Skipping aarch64 Linux (cross not installed)"; exit 0; fi
+    if ! command -v cross >/dev/null 2>&1; then echo "build-linux-cross: cross not installed; run 'cargo install cross'" >&2; exit 1; fi
     cross build -p capsule-core --target aarch64-unknown-linux-gnu
 
 [group('rust')]

--- a/justfile
+++ b/justfile
@@ -80,6 +80,64 @@ test-coverage-rust:
 build-rust:
     cargo build --workspace --exclude capsule-sdk
 
+# ── Cross-compilation: FFI / mobile targets ──────────────────────────────────
+# capsule-core builds as cdylib+staticlib (see its [lib] crate-type) so it links
+# into iOS/Android. This is the formal definition of the targets the crate
+# verifies; .github/workflows/ci.yml `rust-cross` enforces it.
+#
+#   Tier 1 — CI-gated on every PR:
+#     x86_64-unknown-linux-gnu      (host; covered by the `rust` workspace build)
+#     aarch64-apple-ios             aarch64-apple-ios-sim   x86_64-apple-ios
+#     aarch64-apple-darwin          x86_64-apple-darwin
+#     aarch64-linux-android         armv7-linux-androideabi
+#     x86_64-linux-android          i686-linux-android
+#   Tier 2 — best-effort (build-only, non-blocking):
+#     x86_64-pc-windows-msvc        aarch64-unknown-linux-gnu
+#
+# Apple builds natively on macOS; Android via cargo-ndk; aarch64 Linux via
+# `cross` (none can build Apple). The build-* recipes self-skip when their
+# toolchain/OS is absent, so `build-targets` is safe to run anywhere.
+
+[group('rust')]
+targets-add:
+    rustup target add \
+        aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios \
+        aarch64-apple-darwin x86_64-apple-darwin \
+        aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+    cargo install cargo-ndk
+
+[group('rust')]
+build-apple:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "$(uname)" != "Darwin" ]; then echo "Skipping Apple targets (not macOS)"; exit 0; fi
+    for t in aarch64-apple-darwin x86_64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios; do
+        echo ":: building capsule-core for $t"
+        cargo build -p capsule-core --target "$t"
+    done
+
+[group('rust')]
+build-android:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v cargo-ndk >/dev/null 2>&1; then echo "Skipping Android (cargo-ndk missing; run 'just targets-add')"; exit 0; fi
+    if [ -z "${ANDROID_NDK_HOME:-}${ANDROID_NDK_ROOT:-}" ]; then echo "Skipping Android (ANDROID_NDK_HOME unset)"; exit 0; fi
+    cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 --platform 26 build -p capsule-core
+
+[group('rust')]
+build-linux-cross:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v cross >/dev/null 2>&1; then echo "Skipping aarch64 Linux (cross not installed)"; exit 0; fi
+    cross build -p capsule-core --target aarch64-unknown-linux-gnu
+
+[group('rust')]
+build-windows:
+    cargo build -p capsule-core --target x86_64-pc-windows-msvc
+
+[group('rust')]
+build-targets: build-apple build-android build-linux-cross
+
 # ── Web ──────────────────────────────────────────────────────────────────────
 
 [group('web')]


### PR DESCRIPTION
## Context

This is **PR 1 of 3** in the stack that lands **hardware-bound key storage**
(`DEFERRED.md` → *Hardware-bound key storage*; design:
`capsule-docs/.../design/cryptography/keys.md`). The design requires device
private keys to be generated inside and never leave hardware (Secure Enclave /
StrongBox / TPM), which first needs the crate to cross-compile to mobile and the
core to be callable from Swift/Kotlin. The stack:

1. **This PR — cross-compilation targets + CI.**
2. `Signer` seam + uniffi FFI surface (exposes `capsule-core` to Kotlin/Swift).
3. Hardware-bound key storage (foreign `HardwareSigner` + smoke harness).

## What this PR does

- **`capsule-core` `[lib] crate-type = ["lib", "cdylib", "staticlib"]`** — the
  `cdylib` is the Android `.so` and the `staticlib` the iOS XCFramework input for
  the upcoming uniffi bindings. The `lib` (rlib) is unchanged, so the rest of the
  workspace links `capsule-core` exactly as before. **No API or behavior change.**
- **Formally defines the supported targets** (enumerated in the `justfile`
  cross-compilation header, enforced by CI):
  - **Tier 1 (CI-gated):** `x86_64-unknown-linux-gnu` (host), `aarch64-apple-ios`,
    `aarch64-apple-ios-sim`, `x86_64-apple-ios`, `aarch64-apple-darwin`,
    `x86_64-apple-darwin`, `aarch64-linux-android`, `armv7-linux-androideabi`,
    `x86_64-linux-android`, `i686-linux-android`.
  - **Tier 2 (best-effort, non-blocking):** `x86_64-pc-windows-msvc`,
    `aarch64-unknown-linux-gnu`.
- **`justfile`** recipes: `targets-add`, `build-apple`, `build-android`,
  `build-linux-cross`, `build-windows`, `build-targets`. Apple builds natively on
  macOS, Android via `cargo-ndk`, aarch64 Linux via `cross` (none can build
  Apple). Recipes self-skip when their toolchain/OS is absent, so
  `just build-targets` is safe to run anywhere.
- **`Cross.toml`** pins the `cross` image for `aarch64-unknown-linux-gnu`.
- **`.github/workflows/ci.yml`**: new `rust-cross` matrix wired into the
  `required` aggregator; Tier-2 legs are `continue-on-error`. The `changes` path
  filter now also watches `justfile`, `Cross.toml`, and `.cargo/**`.

## Verification

- `cargo build -p capsule-core` and `cargo build -p capsule-cli` build cleanly
  (rlib consumers unaffected); the host build emits `libcapsule_core.{a,dylib}`.
- `just build-apple` builds all five Apple targets locally on macOS — including
  `rusqlite`'s bundled SQLite (C) and the full RustCrypto stack — confirming the
  mobile cross-compile premise.
- `just build-android` / `just build-linux-cross` self-skip when `cargo-ndk` /
  `cross` are absent.
- CI `rust-cross` exercises Apple + Android (gating) and Windows + aarch64 Linux
  (best-effort).