### PR TITLE
feat(ios): privacy-first diagnostics & crash reporting (closes #10)

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -49,9 +49,14 @@ jobs:
       - name: Build & test
         run: |
           set -o pipefail
+          # Resolve an available iPhone simulator at runtime — the runner image's
+          # specific models churn (e.g. iPhone 16 → 17), so pinning a name breaks.
+          sim_id=$(xcrun simctl list devices available --json \
+            | jq -r '[.devices | to_entries[] | select(.key | test("iOS")) | .value[] | select(.name | startswith("iPhone"))][0].udid')
+          echo "Using simulator $sim_id"
           xcodebuild test \
             -workspace capsule-swift/Capsule.xcworkspace \
             -scheme Capsule \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination "id=$sim_id" \
             CODE_SIGNING_ALLOWED=NO | mise -C capsule-swift exec -- xcbeautify

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -20,7 +20,11 @@ concurrency:
 jobs:
   build:
     name: Build & test Capsule.app
-    runs-on: macos-15
+    # macOS 26 host: provides libswiftCompatibilitySpan.dylib natively, which the
+    # Xcode 26 / Swift 6.2 toolchain's prebuilt CLIs (tuist, xcbeautify) link
+    # against via @rpath. On macos-15 dyld can't find it and `tuist generate`
+    # aborts. See https://developer.apple.com/forums/thread/817488
+    runs-on: macos-26
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/capsule-swift/App/iOS/Resources/PrivacyInfo.xcprivacy
+++ b/capsule-swift/App/iOS/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Capsule does not track users across apps or websites. -->
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+
+    <!-- Diagnostics data the app is capable of collecting when the user opts in
+         to uploads to their own self-hosted endpoint. None is linked to the
+         user's identity and none is used for tracking. By default nothing leaves
+         the device. -->
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeCrashData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePerformanceData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+    </array>
+
+    <!-- Required-reason API declarations. -->
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <!-- UserDefaults: hidden-asset set, consent, crash sentinel. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+        <!-- Disk space: coarse free-space bucket in diagnostics metadata. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+        <!-- File timestamps: managed library / import pipeline files in the app container. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/capsule-swift/App/iOS/Sources/AppEnvironment.swift
+++ b/capsule-swift/App/iOS/Sources/AppEnvironment.swift
@@ -1,4 +1,5 @@
 import AssetKit
+import CapsuleDiagnostics
 import FeatureTimeline
 import Foundation
 import ImagePipeline
@@ -19,6 +20,11 @@ struct AppEnvironment {
     let thumbnails: any ThumbnailProvider
     let mediaLoader: ViewerMediaLoader
     let importer: LibraryImporter
+
+    /// Persisted diagnostics & telemetry consent (local-only by default).
+    let consentStore: ConsentStore
+    /// Wires MetricKit, breadcrumbs, the crash prompt, and bug-report export.
+    let diagnostics: DiagnosticsCoordinator
 
     init() {
         let layout = ManagedLibraryLayout(root: Self.libraryRoot())
@@ -42,6 +48,10 @@ struct AppEnvironment {
         thumbnails = ImagePipeline()
         mediaLoader = ViewerMediaLoader()
         importer = LibraryImporter(importService: importService, managedProvider: managedProvider)
+
+        let consent = ConsentStore()
+        consentStore = consent
+        diagnostics = DiagnosticsCoordinator(consent: consent)
     }
 
     /// The managed library's root, falling back to the temporary directory if

--- a/capsule-swift/App/iOS/Sources/CapsuleApp.swift
+++ b/capsule-swift/App/iOS/Sources/CapsuleApp.swift
@@ -8,6 +8,8 @@ struct CapsuleApp: App {
 
     init() {
         CapsuleLog.app.info("Capsule launching")
+        let diagnostics = environment.diagnostics
+        Task { await diagnostics.start() }
     }
 
     var body: some Scene {

--- a/capsule-swift/App/iOS/Sources/RootView.swift
+++ b/capsule-swift/App/iOS/Sources/RootView.swift
@@ -1,3 +1,5 @@
+import CapsuleDiagnostics
+import CapsuleFoundation
 import CapsuleUI
 import FeatureCollections
 import FeatureSearch
@@ -5,12 +7,18 @@ import FeatureTimeline
 import SwiftUI
 import UIKit
 
-/// The app's root tab shell: Library, Albums, and Search.
+/// The app's root tab shell: Library, Collections, Search, and Settings.
 ///
 /// A compact `TabView` today; Phase 7 adds the `NavigationSplitView` layout for
-/// regular-width (iPad) size classes.
+/// regular-width (iPad) size classes. This view also hosts the app-wide
+/// diagnostics hooks: low-memory recording, clean-shutdown tracking, and the
+/// "crashed last launch?" prompt.
 struct RootView: View {
     let environment: AppEnvironment
+
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var crashReportOffered = false
+    @State private var crashReport: DiagnosticsReport?
 
     var body: some View {
         TabView {
@@ -42,13 +50,52 @@ struct RootView: View {
                     mediaLoader: environment.mediaLoader
                 )
             }
+            Tab("Settings", systemImage: "gearshape") {
+                SettingsView(
+                    consentStore: environment.consentStore,
+                    diagnostics: environment.diagnostics
+                )
+            }
         }
         .tabViewStyle(.sidebarAdaptable)
         .capsuleTabBarMinimizeOnScroll()
         .onReceive(
             NotificationCenter.default.publisher(for: UIApplication.didReceiveMemoryWarningNotification)
         ) { _ in
+            Diagnostics.shared.record(.memoryWarning)
             Task { await environment.thumbnails.flushCaches() }
         }
+        .onChange(of: scenePhase) { _, phase in
+            switch phase {
+            case .background:
+                Task { await environment.diagnostics.noteEnteredBackground() }
+            case .active:
+                Task { await environment.diagnostics.noteBecameActive() }
+            default:
+                break
+            }
+        }
+        .task {
+            if await environment.diagnostics.shouldOfferCrashReport() {
+                crashReportOffered = true
+            }
+        }
+        .alert("Capsule quit unexpectedly last time", isPresented: $crashReportOffered) {
+            Button("Send Report") {
+                Task {
+                    let bundle = await environment.diagnostics.makeReportBundle()
+                    await environment.diagnostics.acknowledgeCrashReport()
+                    if let data = try? bundle.jsonData() {
+                        crashReport = DiagnosticsReport(data: data)
+                    }
+                }
+            }
+            Button("Not Now", role: .cancel) {
+                Task { await environment.diagnostics.acknowledgeCrashReport() }
+            }
+        } message: {
+            Text("A redacted diagnostic report can help us fix the crash. It contains no photos or album contents.")
+        }
+        .sheet(item: $crashReport) { DiagnosticsReportView(report: $0) }
     }
 }

--- a/capsule-swift/App/iOS/Sources/Settings/DiagnosticsReportView.swift
+++ b/capsule-swift/App/iOS/Sources/Settings/DiagnosticsReportView.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+/// A redacted diagnostics report ready to share, wrapped for `.sheet(item:)`.
+struct DiagnosticsReport: Identifiable {
+    let id = UUID()
+    let data: Data
+}
+
+/// Presents the system share sheet for a diagnostics report.
+///
+/// The bundle is written to a temporary `.json` file so the share sheet offers
+/// Mail / Files / AirDrop with a sensible filename. Works entirely on-device —
+/// no backend required.
+struct DiagnosticsReportView: UIViewControllerRepresentable {
+    let report: DiagnosticsReport
+
+    func makeUIViewController(context _: Context) -> UIActivityViewController {
+        let url = FileManager.default.temporaryDirectory.appending(path: "capsule-diagnostics.json")
+        try? report.data.write(to: url, options: .atomic)
+        return UIActivityViewController(activityItems: [url], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_: UIActivityViewController, context _: Context) {}
+}

--- a/capsule-swift/App/iOS/Sources/Settings/SettingsView.swift
+++ b/capsule-swift/App/iOS/Sources/Settings/SettingsView.swift
@@ -94,7 +94,7 @@ struct SettingsView: View {
         persist { $0.uploadEndpoint = url }
     }
 
-    private func persist(_ transform: @escaping (inout DiagnosticsConsent) -> Void) {
+    private func persist(_ transform: @escaping @Sendable (inout DiagnosticsConsent) -> Void) {
         Task { await consentStore.update(transform) }
     }
 

--- a/capsule-swift/App/iOS/Sources/Settings/SettingsView.swift
+++ b/capsule-swift/App/iOS/Sources/Settings/SettingsView.swift
@@ -1,0 +1,121 @@
+import CapsuleDiagnostics
+import CapsuleFoundation
+import SwiftUI
+
+/// Privacy & Diagnostics settings: consent toggles, an optional self-hosted
+/// upload endpoint, and a user-initiated "Report a Problem" flow.
+///
+/// Local on-device diagnostics are on by default; uploads are strictly opt-in.
+/// The report is assembled by the ``DiagnosticsCoordinator`` (redacted) and
+/// shared via the system share sheet.
+struct SettingsView: View {
+    let consentStore: ConsentStore
+    let diagnostics: DiagnosticsCoordinator
+
+    @State private var consent: DiagnosticsConsent = .privacyDefault
+    @State private var endpointText = ""
+    @State private var report: DiagnosticsReport?
+    @State private var isBuildingReport = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Toggle("Share On-Device Diagnostics", isOn: diagnosticsBinding)
+                } header: {
+                    Text("Diagnostics")
+                } footer: {
+                    Text("Collects crash and performance diagnostics on this device using Apple's MetricKit. Nothing leaves your device unless you turn on uploads below.")
+                }
+
+                Section {
+                    Toggle("Upload Reports", isOn: uploadBinding)
+                    if consent.remoteUploadEnabled {
+                        TextField("https://your-server/v1/telemetry", text: $endpointText)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .keyboardType(.URL)
+                            .onSubmit(saveEndpoint)
+                            .submitLabel(.done)
+                    }
+                } header: {
+                    Text("Self-Hosted Upload")
+                } footer: {
+                    Text("Optionally send diagnostic reports to your own Capsule server. Off by default — Capsule never sends anything to a third party.")
+                }
+
+                Section {
+                    Button("Report a Problem…") {
+                        Task { await buildReport() }
+                    }
+                    .disabled(isBuildingReport)
+                } footer: {
+                    Text("Builds a redacted report — recent logs, device info, and the last crash. No photos or album contents are included. You choose where to send it.")
+                }
+
+                Section {
+                    LabeledContent("Version", value: appVersion)
+                }
+            }
+            .navigationTitle("Settings")
+            .task { await load() }
+            .sheet(item: $report) { DiagnosticsReportView(report: $0) }
+        }
+    }
+
+    // MARK: Bindings
+
+    private var diagnosticsBinding: Binding<Bool> {
+        Binding(
+            get: { consent.diagnosticsEnabled },
+            set: { newValue in
+                consent.diagnosticsEnabled = newValue
+                persist { $0.diagnosticsEnabled = newValue }
+            }
+        )
+    }
+
+    private var uploadBinding: Binding<Bool> {
+        Binding(
+            get: { consent.remoteUploadEnabled },
+            set: { newValue in
+                consent.remoteUploadEnabled = newValue
+                persist { $0.remoteUploadEnabled = newValue }
+            }
+        )
+    }
+
+    // MARK: Actions
+
+    private func saveEndpoint() {
+        let trimmed = endpointText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let url = trimmed.isEmpty ? nil : URL(string: trimmed)
+        consent.uploadEndpoint = url
+        persist { $0.uploadEndpoint = url }
+    }
+
+    private func persist(_ transform: @escaping (inout DiagnosticsConsent) -> Void) {
+        Task { await consentStore.update(transform) }
+    }
+
+    private func load() async {
+        consent = await consentStore.current()
+        endpointText = consent.uploadEndpoint?.absoluteString ?? ""
+    }
+
+    private func buildReport() async {
+        isBuildingReport = true
+        defer { isBuildingReport = false }
+        let bundle = await diagnostics.makeReportBundle()
+        if let data = try? bundle.jsonData() {
+            report = DiagnosticsReport(data: data)
+        }
+    }
+
+    private var appVersion: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = info?["CFBundleVersion"] as? String ?? "—"
+        return "\(version) (\(build))"
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Breadcrumbs/BreadcrumbRing.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Breadcrumbs/BreadcrumbRing.swift
@@ -1,0 +1,59 @@
+import CapsuleFoundation
+import Foundation
+
+/// A bounded, in-memory ring buffer of recent diagnostic breadcrumbs.
+///
+/// Conforms to ``DiagnosticsSink`` so it can be installed on ``Diagnostics``.
+/// The most recent `capacity` events are retained to give a crash or bug report
+/// temporal context. Stores only the PII-free event name + a low-cardinality
+/// detail + timestamp — never raw event payloads.
+public actor BreadcrumbRing {
+    /// A single recorded breadcrumb.
+    public struct Breadcrumb: Codable, Sendable, Equatable {
+        public let name: String
+        public let detail: String
+        public let timestamp: Date
+
+        public init(name: String, detail: String, timestamp: Date) {
+            self.name = name
+            self.detail = detail
+            self.timestamp = timestamp
+        }
+    }
+
+    private var entries: [Breadcrumb] = []
+    private let capacity: Int
+
+    public init(capacity: Int = 50) {
+        self.capacity = max(1, capacity)
+    }
+
+    /// The retained breadcrumbs, oldest first.
+    public func snapshot() -> [Breadcrumb] { entries }
+
+    func append(_ event: DiagnosticEvent, at time: Date) {
+        entries.append(Breadcrumb(name: event.name, detail: Self.detail(for: event), timestamp: time))
+        if entries.count > capacity {
+            entries.removeFirst(entries.count - capacity)
+        }
+    }
+
+    /// A low-cardinality, PII-free detail string for the event.
+    private static func detail(for event: DiagnosticEvent) -> String {
+        switch event {
+        case let .appLaunched(coldStart): "coldStart=\(coldStart)"
+        case .enteredBackground, .memoryWarning: ""
+        case let .photoPermission(granted): "granted=\(granted)"
+        case let .operationFailed(operation): operation.rawValue
+        case let .metricKitDiagnostic(kind, count): "\(kind.rawValue)×\(count)"
+        }
+    }
+}
+
+extension BreadcrumbRing: DiagnosticsSink {
+    /// Records asynchronously: the sink contract is synchronous, so we hop onto
+    /// the actor without blocking the caller.
+    public nonisolated func record(_ event: DiagnosticEvent, at time: Date) {
+        Task { await append(event, at: time) }
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Breadcrumbs/LastWordsStore.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Breadcrumbs/LastWordsStore.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Tracks whether the previous app session shut down cleanly.
+///
+/// This is deliberately **not** a crash handler: capturing a crash in-process
+/// requires async-signal-unsafe work and is fragile. Instead a clean-shutdown
+/// sentinel is written when the app backgrounds and cleared while running; its
+/// absence on the next launch indicates the last session ended abnormally. The
+/// authoritative crash details still come from MetricKit's `MXCrashDiagnostic` —
+/// this is only a fast, coarse signal.
+public actor LastWordsStore {
+    private let defaults: UserDefaults
+    private static let cleanKey = "capsule.diagnostics.cleanShutdown"
+    private static let activeKey = "capsule.diagnostics.sessionActive"
+
+    /// Whether the previous session terminated without a clean shutdown.
+    /// `nonisolated` so callers can read this immutable snapshot synchronously.
+    public nonisolated let previousSessionEndedAbnormally: Bool
+
+    /// - Parameter suiteName: a `UserDefaults` suite; `nil` uses `.standard`.
+    public init(suiteName: String? = nil) {
+        let defaults = suiteName.flatMap { UserDefaults(suiteName: $0) } ?? .standard
+        self.defaults = defaults
+        // A session that started but never marked a clean shutdown ended abnormally.
+        let started = defaults.bool(forKey: Self.activeKey)
+        let clean = defaults.bool(forKey: Self.cleanKey)
+        previousSessionEndedAbnormally = started && !clean
+    }
+
+    /// Mark the current session active and not-yet-clean. Call at launch and
+    /// whenever the app returns to the foreground.
+    public func beginSession() {
+        defaults.set(true, forKey: Self.activeKey)
+        defaults.set(false, forKey: Self.cleanKey)
+    }
+
+    /// Record a clean shutdown. Call when the app enters the background.
+    public func markCleanShutdown() {
+        defaults.set(true, forKey: Self.cleanKey)
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Consent/ConsentStore.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Consent/ConsentStore.swift
@@ -26,7 +26,7 @@ public actor ConsentStore: ConsentReading {
 
     /// Apply a mutation, persist it, and notify observers when it changes.
     @discardableResult
-    public func update(_ transform: (inout DiagnosticsConsent) -> Void) -> DiagnosticsConsent {
+    public func update(_ transform: @Sendable (inout DiagnosticsConsent) -> Void) -> DiagnosticsConsent {
         var updated = consent
         transform(&updated)
         guard updated != consent else { return consent }

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Consent/ConsentStore.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Consent/ConsentStore.swift
@@ -1,0 +1,73 @@
+import CapsuleFoundation
+import Foundation
+
+/// The writable, persisted store of ``DiagnosticsConsent``.
+///
+/// Mirrors the app's persisted-store idiom — `actor` + `UserDefaults` + Codable +
+/// `AsyncStream` change notifications (see `HiddenStore`). On first launch it
+/// returns ``DiagnosticsConsent/privacyDefault`` (local diagnostics on, no
+/// uploads).
+public actor ConsentStore: ConsentReading {
+    private var consent: DiagnosticsConsent
+    private var observers: [UUID: AsyncStream<DiagnosticsConsent>.Continuation] = [:]
+    private let defaults: UserDefaults
+    private static let defaultsKey = "capsule.diagnostics.consent"
+
+    /// - Parameter suiteName: a `UserDefaults` suite to persist into; `nil` uses
+    ///   `.standard`. A `Sendable` `String` (rather than a `UserDefaults`) keeps
+    ///   the actor boundary clean under strict concurrency.
+    public init(suiteName: String? = nil) {
+        let defaults = suiteName.flatMap { UserDefaults(suiteName: $0) } ?? .standard
+        self.defaults = defaults
+        consent = Self.load(from: defaults)
+    }
+
+    public func current() -> DiagnosticsConsent { consent }
+
+    /// Apply a mutation, persist it, and notify observers when it changes.
+    @discardableResult
+    public func update(_ transform: (inout DiagnosticsConsent) -> Void) -> DiagnosticsConsent {
+        var updated = consent
+        transform(&updated)
+        guard updated != consent else { return consent }
+        consent = updated
+        persist()
+        for continuation in observers.values { continuation.yield(updated) }
+        return updated
+    }
+
+    public nonisolated func changes() -> AsyncStream<DiagnosticsConsent> {
+        AsyncStream { continuation in
+            let token = UUID()
+            Task { await self.register(continuation, token: token) }
+            continuation.onTermination = { _ in
+                Task { await self.unregister(token) }
+            }
+        }
+    }
+
+    /// Registers an observer and replays the current value immediately, so
+    /// subscribers (e.g. the coordinator) converge on live state on subscribe.
+    private func register(_ continuation: AsyncStream<DiagnosticsConsent>.Continuation, token: UUID) {
+        observers[token] = continuation
+        continuation.yield(consent)
+    }
+
+    private func unregister(_ token: UUID) {
+        observers[token] = nil
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(consent) else { return }
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+
+    private static func load(from defaults: UserDefaults) -> DiagnosticsConsent {
+        guard let data = defaults.data(forKey: defaultsKey),
+              let consent = try? JSONDecoder().decode(DiagnosticsConsent.self, from: data)
+        else {
+            return .privacyDefault
+        }
+        return consent
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/DiagnosticsCoordinator.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/DiagnosticsCoordinator.swift
@@ -1,0 +1,139 @@
+import CapsuleFoundation
+import Foundation
+
+/// The app-level façade that wires diagnostics together.
+///
+/// Responsibilities:
+/// - install ``DiagnosticsSink``s on ``Diagnostics`` according to consent,
+///   reconciling live as the user toggles preferences;
+/// - drive MetricKit collection (gated on consent);
+/// - track clean shutdown for the "crashed last launch?" prompt;
+/// - build redacted report bundles and, when opted in, upload them.
+///
+/// Main-actor isolated: it is owned by the (`@MainActor`) `AppEnvironment` and
+/// reads `UIDevice` when assembling metadata.
+@MainActor
+public final class DiagnosticsCoordinator {
+    private let diagnostics: Diagnostics
+    private let consentReader: any ConsentReading
+    private let breadcrumbs: BreadcrumbRing
+    private let lastWords: LastWordsStore
+    private let crashStore: CrashDiagnosticStore
+    private let exporter: any DiagnosticsExporter
+    private let uploader: any TelemetryUploader
+    private let metrics: any MetricsCollecting
+
+    private let osLogSink = OSLogDiagnosticsSink()
+    private var metricsRunning = false
+    private var consentTask: Task<Void, Never>?
+
+    public init(
+        consent: any ConsentReading,
+        diagnostics: Diagnostics = .shared,
+        breadcrumbs: BreadcrumbRing = BreadcrumbRing(),
+        lastWords: LastWordsStore = LastWordsStore(),
+        crashStore: CrashDiagnosticStore = CrashDiagnosticStore(),
+        exporter: any DiagnosticsExporter = DefaultDiagnosticsExporter(),
+        uploader: any TelemetryUploader = RemoteTelemetryUploader(),
+        metrics: (any MetricsCollecting)? = nil
+    ) {
+        consentReader = consent
+        self.diagnostics = diagnostics
+        self.breadcrumbs = breadcrumbs
+        self.lastWords = lastWords
+        self.crashStore = crashStore
+        self.exporter = exporter
+        self.uploader = uploader
+        self.metrics = metrics ?? MetricKitSubscriber(
+            diagnostics: diagnostics,
+            crashStore: crashStore,
+            time: SystemTimeSource()
+        )
+    }
+
+    deinit { consentTask?.cancel() }
+
+    /// Boot diagnostics: install sinks per consent, begin the session, observe
+    /// consent changes, and record the launch.
+    public func start() async {
+        let consent = await consentReader.current()
+        reconcile(consent)
+        await lastWords.beginSession()
+        observeConsent()
+        diagnostics.record(.appLaunched(coldStart: true))
+    }
+
+    // MARK: Scene lifecycle
+
+    /// Call when the app enters the background — marks a clean shutdown.
+    public func noteEnteredBackground() async {
+        diagnostics.record(.enteredBackground)
+        await lastWords.markCleanShutdown()
+    }
+
+    /// Call when the app returns to the foreground — re-arms crash detection.
+    public func noteBecameActive() async {
+        await lastWords.beginSession()
+    }
+
+    // MARK: Crash prompt
+
+    /// Whether to offer a "we crashed last time" report — true only when
+    /// diagnostics are enabled and MetricKit delivered a crash since last launch.
+    public func shouldOfferCrashReport() async -> Bool {
+        guard await consentReader.current().diagnosticsEnabled else { return false }
+        return await crashStore.lastCrash() != nil
+    }
+
+    /// Forget the stored crash once the user has acted on the prompt.
+    public func acknowledgeCrashReport() async {
+        await crashStore.clear()
+    }
+
+    // MARK: Reporting
+
+    /// Assemble a redacted diagnostics bundle for sharing or upload.
+    public func makeReportBundle() async -> DiagnosticsBundle {
+        let metadata = DeviceMetadata.current()
+        let crumbs = await breadcrumbs.snapshot()
+        let crash = await crashStore.lastCrash()
+        return await exporter.exportBundle(metadata: metadata, breadcrumbs: crumbs, crash: crash)
+    }
+
+    /// Upload a bundle to the configured endpoint. Throws ``UploadError/disabled``
+    /// when the user has not opted into uploads — callers fall back to the share
+    /// sheet in that case.
+    public func submitReport(_ bundle: DiagnosticsBundle) async throws {
+        let consent = await consentReader.current()
+        guard consent.canUpload, let endpoint = consent.uploadEndpoint else {
+            throw UploadError.disabled
+        }
+        try await uploader.upload(bundle, to: endpoint)
+    }
+
+    // MARK: Internals
+
+    private func observeConsent() {
+        consentTask = Task { [weak self] in
+            guard let self else { return }
+            for await consent in consentReader.changes() {
+                reconcile(consent)
+            }
+        }
+    }
+
+    /// Rebuild the sink set and MetricKit subscription for the given consent.
+    /// Idempotent: the on-device OSLog sink is always present; breadcrumbs and
+    /// MetricKit are present only while diagnostics are enabled.
+    private func reconcile(_ consent: DiagnosticsConsent) {
+        diagnostics.removeAll()
+        diagnostics.install(osLogSink)
+        if consent.diagnosticsEnabled {
+            diagnostics.install(breadcrumbs)
+            if !metricsRunning { metrics.start(); metricsRunning = true }
+        } else if metricsRunning {
+            metrics.stop()
+            metricsRunning = false
+        }
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/CrashDiagnosticStore.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/CrashDiagnosticStore.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Persists the most recent crash summary delivered by MetricKit, so it can be
+/// attached to the next bug report and drive the "crashed last launch?" prompt.
+public actor CrashDiagnosticStore {
+    private var latest: CrashSummary?
+    private let defaults: UserDefaults
+    private static let key = "capsule.diagnostics.lastCrash"
+
+    /// - Parameter suiteName: a `UserDefaults` suite; `nil` uses `.standard`.
+    public init(suiteName: String? = nil) {
+        let defaults = suiteName.flatMap { UserDefaults(suiteName: $0) } ?? .standard
+        self.defaults = defaults
+        latest = Self.load(from: defaults)
+    }
+
+    /// The most recent crash summary, if any.
+    public func lastCrash() -> CrashSummary? { latest }
+
+    /// Persist a freshly delivered crash summary as the latest.
+    public func store(_ summary: CrashSummary) {
+        latest = summary
+        if let data = try? JSONEncoder().encode(summary) {
+            defaults.set(data, forKey: Self.key)
+        }
+    }
+
+    /// Clear the stored crash once the user has acknowledged the prompt.
+    public func clear() {
+        latest = nil
+        defaults.removeObject(forKey: Self.key)
+    }
+
+    private static func load(from defaults: UserDefaults) -> CrashSummary? {
+        guard let data = defaults.data(forKey: Self.key) else { return nil }
+        return try? JSONDecoder().decode(CrashSummary.self, from: data)
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/CrashSummary.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/CrashSummary.swift
@@ -1,0 +1,39 @@
+import CapsuleFoundation
+import Foundation
+
+/// A redacted, PII-free summary of a MetricKit diagnostic.
+///
+/// Holds only numeric exception/signal codes and coarse environment facts
+/// produced by the OS — never call-stack symbols tied to user data, file paths,
+/// or content. Persisted so it can drive the "crashed last launch?" prompt and
+/// be attached to the next bug report.
+public struct CrashSummary: Codable, Sendable, Equatable {
+    public let kind: MetricDiagnosticKind
+    public let exceptionType: Int?
+    public let exceptionCode: Int?
+    public let signal: Int?
+    public let terminationReason: String?
+    public let osVersion: String?
+    public let appBuild: String?
+    public let timestamp: Date
+
+    public init(
+        kind: MetricDiagnosticKind,
+        exceptionType: Int? = nil,
+        exceptionCode: Int? = nil,
+        signal: Int? = nil,
+        terminationReason: String? = nil,
+        osVersion: String? = nil,
+        appBuild: String? = nil,
+        timestamp: Date
+    ) {
+        self.kind = kind
+        self.exceptionType = exceptionType
+        self.exceptionCode = exceptionCode
+        self.signal = signal
+        self.terminationReason = terminationReason
+        self.osVersion = osVersion
+        self.appBuild = appBuild
+        self.timestamp = timestamp
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/DeviceMetadata.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/DeviceMetadata.swift
@@ -1,0 +1,78 @@
+import Foundation
+import UIKit
+
+/// Non-identifying device & app facts attached to a diagnostics bundle.
+///
+/// Deliberately excludes every stable identifier (no UDID / IDFV / IDFA) and any
+/// user content — only coarse environment facts useful for triage. The free-disk
+/// figure is bucketed rather than exact to avoid a fingerprintable value.
+public struct DeviceMetadata: Codable, Sendable, Equatable {
+    public let appVersion: String
+    public let appBuild: String
+    public let systemName: String
+    public let systemVersion: String
+    public let model: String
+    public let locale: String
+    public let freeDiskSpace: DiskSpaceBucket
+
+    public init(
+        appVersion: String,
+        appBuild: String,
+        systemName: String,
+        systemVersion: String,
+        model: String,
+        locale: String,
+        freeDiskSpace: DiskSpaceBucket
+    ) {
+        self.appVersion = appVersion
+        self.appBuild = appBuild
+        self.systemName = systemName
+        self.systemVersion = systemVersion
+        self.model = model
+        self.locale = locale
+        self.freeDiskSpace = freeDiskSpace
+    }
+
+    /// Snapshot the current device & app environment. Main-actor because it
+    /// touches `UIDevice`.
+    @MainActor
+    public static func current(bundle: Bundle = .main) -> DeviceMetadata {
+        let device = UIDevice.current
+        let info = bundle.infoDictionary
+        return DeviceMetadata(
+            appVersion: info?["CFBundleShortVersionString"] as? String ?? "unknown",
+            appBuild: info?["CFBundleVersion"] as? String ?? "unknown",
+            systemName: device.systemName,
+            systemVersion: device.systemVersion,
+            model: device.model,
+            locale: Locale.current.identifier,
+            freeDiskSpace: DiskSpaceBucket.current()
+        )
+    }
+}
+
+/// A coarse free-disk bucket — avoids reporting an exact, fingerprintable byte count.
+public enum DiskSpaceBucket: String, Codable, Sendable, Equatable, CaseIterable {
+    case critical // < 500 MB
+    case low // < 2 GB
+    case moderate // < 10 GB
+    case ample // >= 10 GB
+    case unknown
+
+    static func current() -> DiskSpaceBucket {
+        guard let bytes = try? URL(fileURLWithPath: NSHomeDirectory())
+            .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+            .volumeAvailableCapacityForImportantUsage
+        else { return .unknown }
+        return bucket(forBytes: bytes)
+    }
+
+    static func bucket(forBytes bytes: Int64) -> DiskSpaceBucket {
+        switch bytes {
+        case ..<500_000_000: .critical
+        case ..<2_000_000_000: .low
+        case ..<10_000_000_000: .moderate
+        default: .ample
+        }
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/DiagnosticsBundle.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/DiagnosticsBundle.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// A redacted, self-contained diagnostics report a user can share via the system
+/// share sheet or — when opted in — upload to a self-hosted endpoint.
+///
+/// Everything in here is PII-free by construction: the metadata carries no
+/// identifiers, breadcrumbs and the crash summary are typed/numeric, and the log
+/// excerpt is run through ``Redactor`` before assembly.
+public struct DiagnosticsBundle: Codable, Sendable, Equatable {
+    /// A single redacted log line.
+    public struct LogEntry: Codable, Sendable, Equatable {
+        public let timestamp: Date
+        public let category: String
+        public let level: String
+        public let message: String
+
+        public init(timestamp: Date, category: String, level: String, message: String) {
+            self.timestamp = timestamp
+            self.category = category
+            self.level = level
+            self.message = message
+        }
+    }
+
+    public let createdAt: Date
+    public let metadata: DeviceMetadata
+    public let breadcrumbs: [BreadcrumbRing.Breadcrumb]
+    public let crash: CrashSummary?
+    public let logExcerpt: [LogEntry]
+
+    public init(
+        createdAt: Date,
+        metadata: DeviceMetadata,
+        breadcrumbs: [BreadcrumbRing.Breadcrumb],
+        crash: CrashSummary?,
+        logExcerpt: [LogEntry]
+    ) {
+        self.createdAt = createdAt
+        self.metadata = metadata
+        self.breadcrumbs = breadcrumbs
+        self.crash = crash
+        self.logExcerpt = logExcerpt
+    }
+
+    /// Serialise to stable, pretty-printed JSON for the share sheet or upload body.
+    public func jsonData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(self)
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/DiagnosticsExporter.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/DiagnosticsExporter.swift
@@ -1,0 +1,56 @@
+import CapsuleFoundation
+import Foundation
+
+/// Assembles a redacted ``DiagnosticsBundle`` from the app's diagnostic state.
+public protocol DiagnosticsExporter: Sendable {
+    func exportBundle(
+        metadata: DeviceMetadata,
+        breadcrumbs: [BreadcrumbRing.Breadcrumb],
+        crash: CrashSummary?
+    ) async -> DiagnosticsBundle
+}
+
+/// The production exporter. Reads a recent log excerpt via an injected
+/// ``LogExcerptReader``, **redacts every log message** (defence in depth over
+/// the already-PII-free structured data), and packages everything into a bundle.
+public struct DefaultDiagnosticsExporter: DiagnosticsExporter {
+    private let logReader: any LogExcerptReader
+    private let time: any TimeSource
+    private let window: TimeInterval
+    private let logLimit: Int
+
+    public init(
+        logReader: any LogExcerptReader = OSLogExcerptReader(),
+        time: any TimeSource = SystemTimeSource(),
+        window: TimeInterval = 600,
+        logLimit: Int = 500
+    ) {
+        self.logReader = logReader
+        self.time = time
+        self.window = window
+        self.logLimit = logLimit
+    }
+
+    public func exportBundle(
+        metadata: DeviceMetadata,
+        breadcrumbs: [BreadcrumbRing.Breadcrumb],
+        crash: CrashSummary?
+    ) async -> DiagnosticsBundle {
+        let raw = await logReader.recentEntries(within: window, limit: logLimit)
+        let redacted = raw.map { entry in
+            DiagnosticsBundle.LogEntry(
+                timestamp: entry.timestamp,
+                category: entry.category,
+                level: entry.level,
+                message: Redactor.redact(entry.message)
+            )
+        }
+        return DiagnosticsBundle(
+            createdAt: time.now,
+            metadata: metadata,
+            breadcrumbs: breadcrumbs,
+            crash: crash,
+            logExcerpt: redacted
+        )
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/LogExcerptReader.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/LogExcerptReader.swift
@@ -1,0 +1,56 @@
+import CapsuleFoundation
+import Foundation
+import OSLog
+
+/// Reads recent on-device log entries for inclusion in a report. Abstracted so
+/// the exporter is testable without the (environment-dependent) log store.
+public protocol LogExcerptReader: Sendable {
+    func recentEntries(within interval: TimeInterval, limit: Int) async -> [DiagnosticsBundle.LogEntry]
+}
+
+/// Production reader over `OSLogStore`, scoped to the **current process** (no
+/// special entitlement needed) and filtered to Capsule's subsystems. Returns raw
+/// messages; redaction is applied downstream by the exporter.
+public struct OSLogExcerptReader: LogExcerptReader {
+    public init() {}
+
+    public func recentEntries(within interval: TimeInterval, limit: Int) async -> [DiagnosticsBundle.LogEntry] {
+        do {
+            let store = try OSLogStore(scope: .currentProcessIdentifier)
+            let since = store.position(date: Date().addingTimeInterval(-interval))
+            // Matches both "com.justin13888.capsule" and ".capsule.core".
+            let predicate = NSPredicate(format: "subsystem BEGINSWITH %@", CapsuleLog.subsystem)
+            let entries = try store.getEntries(at: since, matching: predicate)
+            var result: [DiagnosticsBundle.LogEntry] = []
+            for case let entry as OSLogEntryLog in entries {
+                result.append(
+                    DiagnosticsBundle.LogEntry(
+                        timestamp: entry.date,
+                        category: entry.category,
+                        level: Self.label(for: entry.level),
+                        message: entry.composedMessage
+                    )
+                )
+            }
+            // Keep the most recent `limit` entries.
+            return Array(result.suffix(limit))
+        } catch {
+            CapsuleLog.diagnostics.error(
+                "oslog excerpt unavailable: \(error.localizedDescription, privacy: .public)"
+            )
+            return []
+        }
+    }
+
+    private static func label(for level: OSLogEntryLog.Level) -> String {
+        switch level {
+        case .debug: "debug"
+        case .info: "info"
+        case .notice: "notice"
+        case .error: "error"
+        case .fault: "fault"
+        case .undefined: "undefined"
+        @unknown default: "unknown"
+        }
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/Redactor.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Export/Redactor.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Scrubs free-form log text of likely-sensitive tokens before it can leave the
+/// device: absolute file paths and UUID / long-hex identifiers (asset UUIDs,
+/// content hashes, PhotoKit local identifiers).
+///
+/// This is a defence-in-depth net over the structured event enum, which is
+/// already PII-free. It is intentionally aggressive — over-redaction in a
+/// diagnostics excerpt is preferable to a leak.
+enum Redactor {
+    /// The placeholder substituted for any matched token.
+    static let placeholder = "‹redacted›"
+
+    private static let patterns: [NSRegularExpression] = {
+        let expressions = [
+            #"/[A-Za-z0-9._/\-]{3,}"#, // absolute file paths
+            #"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"#, // UUIDs
+            #"[0-9a-fA-F]{32,}"#, // long hex (hashes / identifiers)
+        ]
+        return expressions.compactMap { try? NSRegularExpression(pattern: $0) }
+    }()
+
+    static func redact(_ input: String) -> String {
+        var output = input
+        for regex in patterns {
+            let range = NSRange(output.startIndex..., in: output)
+            output = regex.stringByReplacingMatches(in: output, options: [], range: range, withTemplate: placeholder)
+        }
+        return output
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/MetricKit/CrashSummary+MetricKit.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/MetricKit/CrashSummary+MetricKit.swift
@@ -1,0 +1,19 @@
+import CapsuleFoundation
+import Foundation
+import MetricKit
+
+extension CrashSummary {
+    /// Map a MetricKit crash diagnostic into a PII-free summary.
+    init(from crash: MXCrashDiagnostic, at time: Date) {
+        self.init(
+            kind: .crash,
+            exceptionType: crash.exceptionType?.intValue,
+            exceptionCode: crash.exceptionCode?.intValue,
+            signal: crash.signal?.intValue,
+            terminationReason: crash.terminationReason,
+            osVersion: crash.metaData.osVersion,
+            appBuild: crash.metaData.applicationBuildVersion,
+            timestamp: time
+        )
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/MetricKit/MetricKitSubscriber.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/MetricKit/MetricKitSubscriber.swift
@@ -1,0 +1,56 @@
+import CapsuleFoundation
+import Foundation
+import MetricKit
+
+/// Subscribes to Apple's MetricKit to receive crash, hang, CPU and disk-write
+/// diagnostics plus daily performance metrics — the privacy-safe, OS-symbolicated
+/// path to crash reporting, with no in-process (async-signal-unsafe) handler.
+///
+/// MetricKit delivers payloads on its own queue; this subscriber holds only
+/// immutable references and hops every mutation onto the breadcrumb / crash
+/// actors, so it is safe to mark `@unchecked Sendable`.
+final class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber, MetricsCollecting, @unchecked Sendable {
+    private let diagnostics: Diagnostics
+    private let crashStore: CrashDiagnosticStore
+    private let time: any TimeSource
+
+    init(diagnostics: Diagnostics, crashStore: CrashDiagnosticStore, time: any TimeSource) {
+        self.diagnostics = diagnostics
+        self.crashStore = crashStore
+        self.time = time
+    }
+
+    func start() { MXMetricManager.shared.add(self) }
+    func stop() { MXMetricManager.shared.remove(self) }
+
+    // MARK: MXMetricManagerSubscriber
+
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        guard !payloads.isEmpty else { return }
+        CapsuleLog.diagnostics.info("metrickit metric payloads received: \(payloads.count, privacy: .public)")
+    }
+
+    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+        for payload in payloads { handle(payload) }
+    }
+
+    private func handle(_ payload: MXDiagnosticPayload) {
+        if let crashes = payload.crashDiagnostics, !crashes.isEmpty {
+            let now = time.now
+            for crash in crashes {
+                let summary = CrashSummary(from: crash, at: now)
+                Task { await crashStore.store(summary) }
+            }
+            diagnostics.record(.metricKitDiagnostic(kind: .crash, count: crashes.count))
+        }
+        if let hangs = payload.hangDiagnostics, !hangs.isEmpty {
+            diagnostics.record(.metricKitDiagnostic(kind: .hang, count: hangs.count))
+        }
+        if let cpu = payload.cpuExceptionDiagnostics, !cpu.isEmpty {
+            diagnostics.record(.metricKitDiagnostic(kind: .cpuException, count: cpu.count))
+        }
+        if let disk = payload.diskWriteExceptionDiagnostics, !disk.isEmpty {
+            diagnostics.record(.metricKitDiagnostic(kind: .diskWriteException, count: disk.count))
+        }
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/MetricKit/MetricsCollecting.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/MetricKit/MetricsCollecting.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// The lifecycle seam for OS metric/diagnostic collection.
+///
+/// Abstracted so the coordinator's consent-gated start/stop logic is testable
+/// without registering a real `MXMetricManager` subscriber.
+public protocol MetricsCollecting: AnyObject {
+    /// Begin receiving metric & diagnostic payloads.
+    func start()
+    /// Stop receiving payloads.
+    func stop()
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Sources/Upload/TelemetryUploader.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Sources/Upload/TelemetryUploader.swift
@@ -1,0 +1,78 @@
+import CapsuleFoundation
+import Foundation
+
+/// Uploads a diagnostics bundle to a self-hosted endpoint.
+public protocol TelemetryUploader: Sendable {
+    func upload(_ bundle: DiagnosticsBundle, to endpoint: URL) async throws
+}
+
+/// Errors surfaced by ``RemoteTelemetryUploader``.
+public enum UploadError: Error, Sendable, Equatable {
+    /// Upload was requested while disabled / unconfigured.
+    case disabled
+    /// The server rejected the upload with a non-2xx status.
+    case server(status: Int)
+    /// All retry attempts failed.
+    case exhaustedRetries
+}
+
+/// The transport seam the uploader posts through — the actual `URLSession` call.
+/// Abstracted so retry/backoff logic is testable without real networking.
+public protocol UploadTransport: Sendable {
+    /// Send the request and return the HTTP status code.
+    func send(_ request: URLRequest) async throws -> Int
+}
+
+/// Production transport over `URLSession`.
+public struct URLSessionTransport: UploadTransport {
+    private let session: URLSession
+    public init(session: URLSession = .shared) { self.session = session }
+
+    public func send(_ request: URLRequest) async throws -> Int {
+        let (_, response) = try await session.data(for: request)
+        return (response as? HTTPURLResponse)?.statusCode ?? -1
+    }
+}
+
+/// The app's **only** network egress: POSTs a bundle as JSON with bounded
+/// exponential-backoff retry. Compiled in, but invoked only when the user has
+/// opted into uploads and configured an endpoint (enforced by the coordinator).
+public struct RemoteTelemetryUploader: TelemetryUploader {
+    private let transport: any UploadTransport
+    private let maxAttempts: Int
+    private let baseBackoff: Duration
+
+    public init(
+        transport: any UploadTransport = URLSessionTransport(),
+        maxAttempts: Int = 3,
+        baseBackoff: Duration = .milliseconds(500)
+    ) {
+        self.transport = transport
+        self.maxAttempts = max(1, maxAttempts)
+        self.baseBackoff = baseBackoff
+    }
+
+    public func upload(_ bundle: DiagnosticsBundle, to endpoint: URL) async throws {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try bundle.jsonData()
+
+        var attempt = 0
+        while true {
+            attempt += 1
+            do {
+                let status = try await transport.send(request)
+                if (200 ..< 300).contains(status) { return }
+                throw UploadError.server(status: status)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try Task.checkCancellation()
+                guard attempt < maxAttempts else { throw UploadError.exhaustedRetries }
+                // Exponential backoff: base × 2^(attempt-1).
+                try? await Task.sleep(for: baseBackoff * (1 << (attempt - 1)))
+            }
+        }
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Tests/ConsentStoreTests.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Tests/ConsentStoreTests.swift
@@ -1,0 +1,41 @@
+import CapsuleFoundation
+import Foundation
+import Testing
+
+@testable import CapsuleDiagnostics
+
+@Suite("ConsentStore")
+struct ConsentStoreTests {
+    @Test("defaults to the privacy default on first launch")
+    func defaultsToPrivacyDefault() async {
+        let store = ConsentStore(suiteName: makeSuiteName())
+        #expect(await store.current() == .privacyDefault)
+    }
+
+    @Test("update persists and reloads across instances")
+    func persistsAndReloads() async {
+        let suite = makeSuiteName()
+        let store = ConsentStore(suiteName: suite)
+        await store.update {
+            $0.remoteUploadEnabled = true
+            $0.uploadEndpoint = URL(string: "https://capsule.example/v1/telemetry")
+        }
+
+        let reloaded = await ConsentStore(suiteName: suite).current()
+        #expect(reloaded.remoteUploadEnabled)
+        #expect(reloaded.uploadEndpoint == URL(string: "https://capsule.example/v1/telemetry"))
+    }
+
+    @Test("changes() replays current then yields updates")
+    func changesReplayThenYield() async {
+        let store = ConsentStore(suiteName: makeSuiteName())
+        var iterator = store.changes().makeAsyncIterator()
+
+        let initial = await iterator.next()
+        #expect(initial == .privacyDefault)
+
+        await store.update { $0.diagnosticsEnabled = false }
+        let updated = await iterator.next()
+        #expect(updated?.diagnosticsEnabled == false)
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Tests/DiagnosticsCoordinatorTests.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Tests/DiagnosticsCoordinatorTests.swift
@@ -1,0 +1,128 @@
+import CapsuleFoundation
+import CapsuleTestSupport
+import Foundation
+import Testing
+
+@testable import CapsuleDiagnostics
+
+@MainActor
+@Suite("DiagnosticsCoordinator consent gating")
+struct DiagnosticsCoordinatorTests {
+    private func makeCoordinator(
+        consent: DiagnosticsConsent,
+        diagnostics: Diagnostics,
+        breadcrumbs: BreadcrumbRing,
+        metrics: MockMetricsCollector,
+        uploader: MockTelemetryUploader = MockTelemetryUploader()
+    ) -> (DiagnosticsCoordinator, MockConsentReading) {
+        let reader = MockConsentReading(consent)
+        let suite = makeSuiteName()
+        let coordinator = DiagnosticsCoordinator(
+            consent: reader,
+            diagnostics: diagnostics,
+            breadcrumbs: breadcrumbs,
+            lastWords: LastWordsStore(suiteName: suite),
+            crashStore: CrashDiagnosticStore(suiteName: suite),
+            exporter: DefaultDiagnosticsExporter(logReader: MockLogExcerptReader([])),
+            uploader: uploader,
+            metrics: metrics
+        )
+        return (coordinator, reader)
+    }
+
+    @Test("enabled: installs breadcrumbs and starts MetricKit")
+    func enabledInstallsSinks() async {
+        let diagnostics = Diagnostics(time: FixedTimeSource())
+        let breadcrumbs = BreadcrumbRing(capacity: 16)
+        let metrics = MockMetricsCollector()
+        let (coordinator, _) = makeCoordinator(
+            consent: DiagnosticsConsent(diagnosticsEnabled: true),
+            diagnostics: diagnostics, breadcrumbs: breadcrumbs, metrics: metrics
+        )
+
+        await coordinator.start()
+        #expect(metrics.isStarted)
+
+        diagnostics.record(.memoryWarning)
+        let recorded = await poll { await breadcrumbs.snapshot().contains { $0.name == "memory_warning" } }
+        #expect(recorded)
+        withExtendedLifetime(coordinator) {}
+    }
+
+    @Test("disabled: MetricKit stays off and no breadcrumbs are kept")
+    func disabledKeepsNothing() async {
+        let diagnostics = Diagnostics(time: FixedTimeSource())
+        let breadcrumbs = BreadcrumbRing(capacity: 16)
+        let metrics = MockMetricsCollector()
+        let (coordinator, _) = makeCoordinator(
+            consent: DiagnosticsConsent(diagnosticsEnabled: false),
+            diagnostics: diagnostics, breadcrumbs: breadcrumbs, metrics: metrics
+        )
+
+        await coordinator.start()
+        #expect(metrics.isStarted == false)
+
+        diagnostics.record(.memoryWarning)
+        // Give any stray async hop a chance, then assert nothing landed.
+        _ = await poll(timeout: .milliseconds(200)) { await !breadcrumbs.snapshot().isEmpty }
+        #expect(await breadcrumbs.snapshot().isEmpty)
+        withExtendedLifetime(coordinator) {}
+    }
+
+    @Test("toggling diagnostics off at runtime stops MetricKit")
+    func runtimeToggleStopsMetricKit() async {
+        let diagnostics = Diagnostics(time: FixedTimeSource())
+        let breadcrumbs = BreadcrumbRing(capacity: 16)
+        let metrics = MockMetricsCollector()
+        let (coordinator, reader) = makeCoordinator(
+            consent: DiagnosticsConsent(diagnosticsEnabled: true),
+            diagnostics: diagnostics, breadcrumbs: breadcrumbs, metrics: metrics
+        )
+
+        await coordinator.start()
+        #expect(metrics.isStarted)
+
+        await reader.send(DiagnosticsConsent(diagnosticsEnabled: false))
+        let stopped = await poll { metrics.stopCount >= 1 }
+        #expect(stopped)
+        #expect(metrics.isStarted == false)
+        withExtendedLifetime(coordinator) {}
+    }
+
+    @Test("submitReport without upload consent throws and never uploads")
+    func submitWithoutConsent() async {
+        let uploader = MockTelemetryUploader()
+        let (coordinator, _) = makeCoordinator(
+            consent: DiagnosticsConsent(diagnosticsEnabled: true),
+            diagnostics: Diagnostics(time: FixedTimeSource()),
+            breadcrumbs: BreadcrumbRing(), metrics: MockMetricsCollector(), uploader: uploader
+        )
+        await coordinator.start()
+
+        await #expect(throws: UploadError.disabled) {
+            try await coordinator.submitReport(makeBundle())
+        }
+        #expect(uploader.uploadCount == 0)
+        withExtendedLifetime(coordinator) {}
+    }
+
+    @Test("submitReport with upload consent uploads once")
+    func submitWithConsent() async throws {
+        let uploader = MockTelemetryUploader()
+        let consent = DiagnosticsConsent(
+            diagnosticsEnabled: true,
+            remoteUploadEnabled: true,
+            uploadEndpoint: URL(string: "https://capsule.example/v1/telemetry")
+        )
+        let (coordinator, _) = makeCoordinator(
+            consent: consent,
+            diagnostics: Diagnostics(time: FixedTimeSource()),
+            breadcrumbs: BreadcrumbRing(), metrics: MockMetricsCollector(), uploader: uploader
+        )
+        await coordinator.start()
+
+        try await coordinator.submitReport(makeBundle())
+        #expect(uploader.uploadCount == 1)
+        withExtendedLifetime(coordinator) {}
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Tests/ExportTests.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Tests/ExportTests.swift
@@ -1,0 +1,96 @@
+import CapsuleFoundation
+import CapsuleTestSupport
+import Foundation
+import Testing
+
+@testable import CapsuleDiagnostics
+
+@Suite("Redaction & export")
+struct ExportTests {
+    @Test("Redactor strips paths, UUIDs, and long hex")
+    func redactorStrips() {
+        let path = "/Users/alice/Library/Application Support/Capsule/store.sqlite"
+        let uuid = "B84E8479-475C-4727-A4A4-B77AA9980897"
+        let hash = "deadbeefdeadbeefdeadbeefdeadbeef00112233"
+        let output = Redactor.redact("opening \(path) id \(uuid) hash \(hash)")
+
+        #expect(!output.contains("/Users/alice"))
+        #expect(!output.contains(uuid))
+        #expect(!output.contains(hash))
+        #expect(output.contains(Redactor.placeholder))
+    }
+
+    @Test("exporter redacts log messages and leaks no planted secrets")
+    func exporterRedacts() async throws {
+        let secretPath = "/Users/alice/Library/Capsule/store.sqlite"
+        let secretUUID = "B84E8479-475C-4727-A4A4-B77AA9980897"
+        let reader = MockLogExcerptReader([
+            DiagnosticsBundle.LogEntry(
+                timestamp: Date(timeIntervalSince1970: 1),
+                category: "managed-store",
+                level: "info",
+                message: "opening \(secretPath) id \(secretUUID)"
+            ),
+        ])
+        let exporter = DefaultDiagnosticsExporter(
+            logReader: reader,
+            time: FixedTimeSource(now: Date(timeIntervalSince1970: 5))
+        )
+        let metadata = DeviceMetadata(
+            appVersion: "1.0", appBuild: "1", systemName: "iOS", systemVersion: "18.0",
+            model: "iPhone", locale: "en_US", freeDiskSpace: .ample
+        )
+        let crumb = BreadcrumbRing.Breadcrumb(name: "operation_failed", detail: "delete", timestamp: Date(timeIntervalSince1970: 2))
+
+        let bundle = await exporter.exportBundle(metadata: metadata, breadcrumbs: [crumb], crash: nil)
+
+        #expect(bundle.createdAt == Date(timeIntervalSince1970: 5))
+        #expect(bundle.logExcerpt.first?.message.contains(secretPath) == false)
+        #expect(bundle.logExcerpt.first?.message.contains(secretUUID) == false)
+
+        let data = try bundle.jsonData()
+        let json = try #require(String(bytes: data, encoding: .utf8))
+        #expect(!json.contains(secretPath))
+        #expect(!json.contains(secretUUID))
+    }
+
+    @Test("device metadata carries no stable identifiers")
+    func metadataHasNoIdentifiers() throws {
+        let metadata = DeviceMetadata(
+            appVersion: "1.0", appBuild: "1", systemName: "iOS", systemVersion: "18.0",
+            model: "iPhone", locale: "en_US", freeDiskSpace: .low
+        )
+        let data = try JSONEncoder().encode(metadata)
+        let json = try #require(String(bytes: data, encoding: .utf8)).lowercased()
+        for forbidden in ["idfv", "idfa", "udid", "identifierforvendor", "serial"] {
+            #expect(!json.contains(forbidden))
+        }
+    }
+
+    @Test("disk space buckets by threshold")
+    func diskBuckets() {
+        #expect(DiskSpaceBucket.bucket(forBytes: 100_000_000) == .critical)
+        #expect(DiskSpaceBucket.bucket(forBytes: 1_000_000_000) == .low)
+        #expect(DiskSpaceBucket.bucket(forBytes: 5_000_000_000) == .moderate)
+        #expect(DiskSpaceBucket.bucket(forBytes: 50_000_000_000) == .ample)
+    }
+
+    @Test("bundle round-trips through Codable")
+    func bundleCodable() throws {
+        let bundle = makeBundle()
+        let data = try bundle.jsonData()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(DiagnosticsBundle.self, from: data)
+        #expect(decoded == bundle)
+    }
+
+    @Test("OSLogExcerptReader completes without throwing")
+    func osLogReaderSmoke() async {
+        CapsuleLog.diagnostics.info("diagnostics export smoke marker")
+        // Environment-dependent (the store may be empty in CI): assert only that
+        // the read completes and returns a bounded result.
+        let entries = await OSLogExcerptReader().recentEntries(within: 60, limit: 50)
+        #expect(entries.count <= 50)
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Tests/StoresTests.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Tests/StoresTests.swift
@@ -1,0 +1,93 @@
+import CapsuleFoundation
+import Foundation
+import Testing
+
+@testable import CapsuleDiagnostics
+
+@Suite("BreadcrumbRing")
+struct BreadcrumbRingTests {
+    @Test("evicts the oldest entries beyond capacity")
+    func eviction() async {
+        let ring = BreadcrumbRing(capacity: 3)
+        for index in 0 ..< 5 {
+            await ring.append(.memoryWarning, at: Date(timeIntervalSince1970: TimeInterval(index)))
+        }
+        let snapshot = await ring.snapshot()
+        #expect(snapshot.count == 3)
+        #expect(snapshot.first?.timestamp == Date(timeIntervalSince1970: 2))
+        #expect(snapshot.last?.timestamp == Date(timeIntervalSince1970: 4))
+    }
+
+    @Test("records PII-free summaries via the sink path")
+    func sinkPath() async {
+        let ring = BreadcrumbRing(capacity: 10)
+        ring.record(.operationFailed(operation: .share), at: Date(timeIntervalSince1970: 1))
+        let recorded = await poll {
+            await ring.snapshot().contains { $0.name == "operation_failed" && $0.detail == "share" }
+        }
+        #expect(recorded)
+    }
+
+    @Test("is lossless under concurrent appends")
+    func concurrency() async {
+        let ring = BreadcrumbRing(capacity: 1000)
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0 ..< 300 {
+                group.addTask { await ring.append(.memoryWarning, at: Date(timeIntervalSince1970: TimeInterval(index))) }
+            }
+        }
+        #expect(await ring.snapshot().count == 300)
+    }
+}
+
+@Suite("LastWordsStore")
+struct LastWordsStoreTests {
+    @Test("a fresh install reports no abnormal termination")
+    func fresh() {
+        let store = LastWordsStore(suiteName: makeSuiteName())
+        #expect(store.previousSessionEndedAbnormally == false)
+    }
+
+    @Test("a session without a clean shutdown is flagged on next launch")
+    func abnormal() async {
+        let suite = makeSuiteName()
+        await LastWordsStore(suiteName: suite).beginSession()
+        // No markCleanShutdown — simulate a crash.
+        let next = LastWordsStore(suiteName: suite)
+        #expect(next.previousSessionEndedAbnormally)
+    }
+
+    @Test("a clean shutdown is not flagged")
+    func clean() async {
+        let suite = makeSuiteName()
+        let session = LastWordsStore(suiteName: suite)
+        await session.beginSession()
+        await session.markCleanShutdown()
+        let next = LastWordsStore(suiteName: suite)
+        #expect(next.previousSessionEndedAbnormally == false)
+    }
+}
+
+@Suite("CrashDiagnosticStore")
+struct CrashDiagnosticStoreTests {
+    @Test("stores, reloads, and clears the latest crash")
+    func roundTrip() async {
+        let suite = makeSuiteName()
+        let store = CrashDiagnosticStore(suiteName: suite)
+        #expect(await store.lastCrash() == nil)
+
+        let summary = CrashSummary(
+            kind: .crash, exceptionType: 1, signal: 11,
+            terminationReason: "test", osVersion: "18.0", appBuild: "1",
+            timestamp: Date(timeIntervalSince1970: 10)
+        )
+        await store.store(summary)
+        #expect(await store.lastCrash() == summary)
+
+        let reloaded = CrashDiagnosticStore(suiteName: suite)
+        #expect(await reloaded.lastCrash() == summary)
+
+        await store.clear()
+        #expect(await store.lastCrash() == nil)
+    }
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Tests/TestHelpers.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Tests/TestHelpers.swift
@@ -1,0 +1,44 @@
+import CapsuleDiagnostics
+import Foundation
+
+/// A fresh, isolated `UserDefaults` suite name per call, so persisted-store
+/// tests don't collide.
+func makeSuiteName() -> String {
+    "capsule.test.\(UUID().uuidString)"
+}
+
+/// A stable upload endpoint for uploader tests (force-unwrap free).
+func testEndpoint() -> URL {
+    URL(string: "https://capsule.example/v1/telemetry") ?? URL(filePath: "/")
+}
+
+/// A minimal, identifier-free bundle for tests that just need a payload.
+func makeBundle() -> DiagnosticsBundle {
+    DiagnosticsBundle(
+        createdAt: Date(timeIntervalSince1970: 0),
+        metadata: DeviceMetadata(
+            appVersion: "1.0",
+            appBuild: "1",
+            systemName: "iOS",
+            systemVersion: "18.0",
+            model: "iPhone",
+            locale: "en_US",
+            freeDiskSpace: .ample
+        ),
+        breadcrumbs: [],
+        crash: nil,
+        logExcerpt: []
+    )
+}
+
+/// Polls `condition` until it holds or the timeout elapses. Used to await the
+/// effects of fire-and-forget actor hops (sinks, observers) deterministically.
+@discardableResult
+func poll(timeout: Duration = .seconds(2), _ condition: @Sendable () async -> Bool) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if await condition() { return true }
+        try? await Task.sleep(for: .milliseconds(5))
+    }
+    return await condition()
+}

--- a/capsule-swift/Modules/CapsuleDiagnostics/Tests/UploaderTests.swift
+++ b/capsule-swift/Modules/CapsuleDiagnostics/Tests/UploaderTests.swift
@@ -1,0 +1,43 @@
+import CapsuleFoundation
+import CapsuleTestSupport
+import Foundation
+import Testing
+
+@testable import CapsuleDiagnostics
+
+@Suite("RemoteTelemetryUploader retry")
+struct UploaderTests {
+    private let endpoint = testEndpoint()
+
+    @Test("succeeds after transient failures")
+    func retriesThenSucceeds() async throws {
+        let transport = MockUploadTransport(failuresBeforeSuccess: 2)
+        let uploader = RemoteTelemetryUploader(transport: transport, maxAttempts: 3, baseBackoff: .milliseconds(1))
+
+        try await uploader.upload(makeBundle(), to: endpoint)
+
+        #expect(transport.sendCount == 3)
+    }
+
+    @Test("throws exhaustedRetries after the attempt budget")
+    func exhaustsRetries() async {
+        let transport = MockUploadTransport(failuresBeforeSuccess: 10)
+        let uploader = RemoteTelemetryUploader(transport: transport, maxAttempts: 3, baseBackoff: .milliseconds(1))
+
+        await #expect(throws: UploadError.exhaustedRetries) {
+            try await uploader.upload(makeBundle(), to: endpoint)
+        }
+        #expect(transport.sendCount == 3)
+    }
+
+    @Test("a non-2xx status is treated as a failure")
+    func nonSuccessStatusFails() async {
+        let transport = MockUploadTransport(failuresBeforeSuccess: 0, successStatus: 418)
+        let uploader = RemoteTelemetryUploader(transport: transport, maxAttempts: 2, baseBackoff: .milliseconds(1))
+
+        await #expect(throws: UploadError.exhaustedRetries) {
+            try await uploader.upload(makeBundle(), to: endpoint)
+        }
+        #expect(transport.sendCount == 2)
+    }
+}

--- a/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/DiagnosticEvent.swift
+++ b/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/DiagnosticEvent.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// A privacy-safe diagnostic signal — counts and categories only, never photo
+/// content, asset identifiers, file paths, or free-form text.
+///
+/// Events feed two destinations: Apple unified logging (always, on-device) and,
+/// when the user has opted in, a bounded breadcrumb ring attached to bug
+/// reports. Keeping the payloads to a closed enum makes accidental PII leakage
+/// a compile error rather than a review catch.
+public enum DiagnosticEvent: Sendable, Equatable {
+    /// The app finished launching. `coldStart` is `false` for warm resumes.
+    case appLaunched(coldStart: Bool)
+    /// The app moved to the background — used to mark a clean shutdown.
+    case enteredBackground
+    /// The system delivered a low-memory warning.
+    case memoryWarning
+    /// The user granted or denied photo-library access.
+    case photoPermission(granted: Bool)
+    /// A non-fatal failure in a named operation. Carries no error text.
+    case operationFailed(operation: DiagnosticOp)
+    /// A summarised MetricKit diagnostic (crash / hang / CPU / disk-write).
+    case metricKitDiagnostic(kind: MetricDiagnosticKind, count: Int)
+
+    /// A stable, low-cardinality identifier, safe to log and serialise.
+    public var name: String {
+        switch self {
+        case .appLaunched: "app_launched"
+        case .enteredBackground: "entered_background"
+        case .memoryWarning: "memory_warning"
+        case .photoPermission: "photo_permission"
+        case .operationFailed: "operation_failed"
+        case .metricKitDiagnostic: "metrickit_diagnostic"
+        }
+    }
+}
+
+/// The closed set of operations that can report a non-fatal failure.
+public enum DiagnosticOp: String, Sendable, CaseIterable, Equatable, Codable {
+    case timelineLoad
+    case importRun
+    case delete
+    case share
+    case albumCreate
+    case search
+    case viewerLoad
+}
+
+/// The category of an Apple MetricKit diagnostic payload.
+public enum MetricDiagnosticKind: String, Sendable, CaseIterable, Equatable, Codable {
+    case crash
+    case hang
+    case cpuException
+    case diskWriteException
+}

--- a/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/Diagnostics.swift
+++ b/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/Diagnostics.swift
@@ -1,0 +1,51 @@
+import Foundation
+import os
+
+/// The process-wide entry point features use to record diagnostics.
+///
+/// `record` fans an event out to every installed ``DiagnosticsSink`` under a
+/// lightweight unfair lock; it is safe to call from any isolation domain and
+/// never blocks on IO. Callers already importing `CapsuleFoundation` reach it
+/// via ``shared`` with no extra dependency — mirroring how ``CapsuleLog`` is
+/// used. The default install is empty; the app installs the on-device OSLog
+/// sink at launch and further sinks (breadcrumbs, upload) once consent resolves.
+public final class Diagnostics: Sendable {
+    /// The shared instance used across the app.
+    public static let shared = Diagnostics()
+
+    private let sinks = OSAllocatedUnfairLock<[any DiagnosticsSink]>(initialState: [])
+    private let time: any TimeSource
+
+    public init(time: any TimeSource = SystemTimeSource()) {
+        self.time = time
+    }
+
+    /// Add a sink to the fan-out set.
+    public func install(_ sink: any DiagnosticsSink) {
+        sinks.withLock { $0.append(sink) }
+    }
+
+    /// Remove every installed sink (e.g. when the user revokes consent).
+    public func removeAll() {
+        sinks.withLock { $0.removeAll() }
+    }
+
+    /// Record a diagnostic event, fanning it out to every installed sink.
+    ///
+    /// The sink list is copied out of the lock before delivery so a sink's
+    /// `record` never runs while the lock is held.
+    public func record(_ event: DiagnosticEvent) {
+        let now = time.now
+        let current = sinks.withLock { $0 }
+        for sink in current {
+            sink.record(event, at: now)
+        }
+    }
+
+    /// Convenience for the common non-fatal-failure case. Records only the
+    /// operation category — never the underlying error's text — so callers keep
+    /// logging the error itself through ``CapsuleLog`` alongside this call.
+    public func recordError(operation: DiagnosticOp) {
+        record(.operationFailed(operation: operation))
+    }
+}

--- a/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/DiagnosticsConsent.swift
+++ b/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/DiagnosticsConsent.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The user's diagnostics & telemetry preferences.
+///
+/// Privacy-first defaults: on-device diagnostics are on (they never leave the
+/// device), while any network upload is off until the user explicitly enables
+/// it and provides an endpoint.
+public struct DiagnosticsConsent: Codable, Sendable, Equatable {
+    /// Collect MetricKit + on-device diagnostics. Stays on the device.
+    public var diagnosticsEnabled: Bool
+    /// Upload bug reports / diagnostics to ``uploadEndpoint``.
+    public var remoteUploadEnabled: Bool
+    /// The self-hosted endpoint reports are uploaded to, when enabled.
+    public var uploadEndpoint: URL?
+
+    public init(
+        diagnosticsEnabled: Bool = true,
+        remoteUploadEnabled: Bool = false,
+        uploadEndpoint: URL? = nil
+    ) {
+        self.diagnosticsEnabled = diagnosticsEnabled
+        self.remoteUploadEnabled = remoteUploadEnabled
+        self.uploadEndpoint = uploadEndpoint
+    }
+
+    /// The privacy-first default: local diagnostics on, no uploads.
+    public static let privacyDefault = DiagnosticsConsent()
+
+    /// Whether a remote upload may actually be attempted — both opted in and
+    /// pointed at an endpoint.
+    public var canUpload: Bool {
+        remoteUploadEnabled && uploadEndpoint != nil
+    }
+}
+
+/// A read-only view of consent, consulted by sinks and the coordinator.
+public protocol ConsentReading: Sendable {
+    /// The current consent snapshot.
+    func current() async -> DiagnosticsConsent
+    /// A stream that yields the latest consent whenever it changes.
+    func changes() -> AsyncStream<DiagnosticsConsent>
+}

--- a/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/DiagnosticsSink.swift
+++ b/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/DiagnosticsSink.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// A destination for ``DiagnosticEvent``s.
+///
+/// `record` must be cheap and non-blocking: it is called synchronously from the
+/// emitting isolation domain (often the main actor on a hot path), so any IO,
+/// networking, or contended work belongs on the implementation's own
+/// queue/actor, hopped to from inside `record`.
+public protocol DiagnosticsSink: Sendable {
+    func record(_ event: DiagnosticEvent, at time: Date)
+}

--- a/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/OSLogDiagnosticsSink.swift
+++ b/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/OSLogDiagnosticsSink.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A ``DiagnosticsSink`` that writes each event to Apple unified logging under
+/// ``CapsuleLog/diagnostics``.
+///
+/// Always installed: the data stays in the on-device unified log (queryable via
+/// Console.app or `log show`) and never leaves the device, so it is independent
+/// of upload consent. All interpolations are `.public` because the event enum
+/// is PII-free by construction.
+public struct OSLogDiagnosticsSink: DiagnosticsSink {
+    public init() {}
+
+    public func record(_ event: DiagnosticEvent, at _: Date) {
+        switch event {
+        case let .appLaunched(coldStart):
+            CapsuleLog.diagnostics.info("app launched (coldStart: \(coldStart, privacy: .public))")
+        case .enteredBackground:
+            CapsuleLog.diagnostics.debug("entered background")
+        case .memoryWarning:
+            CapsuleLog.diagnostics.notice("memory warning")
+        case let .photoPermission(granted):
+            CapsuleLog.diagnostics.info("photo permission (granted: \(granted, privacy: .public))")
+        case let .operationFailed(operation):
+            CapsuleLog.diagnostics.error("operation failed: \(operation.rawValue, privacy: .public)")
+        case let .metricKitDiagnostic(kind, count):
+            CapsuleLog.diagnostics.error(
+                "metrickit diagnostic: \(kind.rawValue, privacy: .public) ×\(count, privacy: .public)"
+            )
+        }
+    }
+}

--- a/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/TimeSource.swift
+++ b/capsule-swift/Modules/CapsuleFoundation/Sources/Diagnostics/TimeSource.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A source of wall-clock time, injected so time-stamped diagnostics are
+/// deterministic under test.
+public protocol TimeSource: Sendable {
+    /// The current wall-clock instant.
+    var now: Date { get }
+}
+
+/// The production clock, reading the system wall clock.
+public struct SystemTimeSource: TimeSource {
+    public init() {}
+    public var now: Date { Date() }
+}

--- a/capsule-swift/Modules/CapsuleFoundation/Sources/Log.swift
+++ b/capsule-swift/Modules/CapsuleFoundation/Sources/Log.swift
@@ -16,4 +16,5 @@ public enum CapsuleLog {
     public static let assetKit = Logger(subsystem: subsystem, category: "asset-kit")
     public static let imagePipeline = Logger(subsystem: subsystem, category: "image-pipeline")
     public static let interface = Logger(subsystem: subsystem, category: "ui")
+    public static let diagnostics = Logger(subsystem: subsystem, category: "diagnostics")
 }

--- a/capsule-swift/Modules/CapsuleFoundation/Tests/DiagnosticsTests.swift
+++ b/capsule-swift/Modules/CapsuleFoundation/Tests/DiagnosticsTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import os
+import Testing
+
+@testable import CapsuleFoundation
+
+@Suite("Diagnostics emit API")
+struct DiagnosticsEmitTests {
+    /// A `Sendable` sink that records every event for assertions.
+    final class RecordingSink: DiagnosticsSink {
+        private let entries = OSAllocatedUnfairLock<[(DiagnosticEvent, Date)]>(initialState: [])
+
+        func record(_ event: DiagnosticEvent, at time: Date) {
+            entries.withLock { $0.append((event, time)) }
+        }
+
+        var events: [DiagnosticEvent] { entries.withLock { $0.map(\.0) } }
+        var times: [Date] { entries.withLock { $0.map(\.1) } }
+    }
+
+    /// A deterministic clock for time-stamp assertions.
+    struct StubClock: TimeSource {
+        let now: Date
+    }
+
+    @Test("record fans out to installed sinks with the injected time")
+    func recordFansOut() {
+        let fixed = Date(timeIntervalSince1970: 1000)
+        let diagnostics = Diagnostics(time: StubClock(now: fixed))
+        let sink = RecordingSink()
+        diagnostics.install(sink)
+
+        diagnostics.record(.memoryWarning)
+        diagnostics.recordError(operation: .timelineLoad)
+
+        #expect(sink.events == [.memoryWarning, .operationFailed(operation: .timelineLoad)])
+        #expect(sink.times == [fixed, fixed])
+    }
+
+    @Test("every installed sink receives the event")
+    func multipleSinks() {
+        let diagnostics = Diagnostics(time: StubClock(now: .init(timeIntervalSince1970: 0)))
+        let first = RecordingSink()
+        let second = RecordingSink()
+        diagnostics.install(first)
+        diagnostics.install(second)
+
+        diagnostics.record(.appLaunched(coldStart: true))
+
+        #expect(first.events == [.appLaunched(coldStart: true)])
+        #expect(second.events == [.appLaunched(coldStart: true)])
+    }
+
+    @Test("removeAll stops delivery")
+    func removeAll() {
+        let diagnostics = Diagnostics(time: StubClock(now: .init(timeIntervalSince1970: 0)))
+        let sink = RecordingSink()
+        diagnostics.install(sink)
+        diagnostics.removeAll()
+
+        diagnostics.record(.memoryWarning)
+
+        #expect(sink.events.isEmpty)
+    }
+
+    @Test("record is safe and lossless under concurrent emit")
+    func concurrentRecord() async {
+        let diagnostics = Diagnostics(time: SystemTimeSource())
+        let sink = RecordingSink()
+        diagnostics.install(sink)
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 200 {
+                group.addTask { diagnostics.record(.memoryWarning) }
+            }
+        }
+
+        #expect(sink.events.count == 200)
+    }
+}
+
+@Suite("DiagnosticsConsent model")
+struct DiagnosticsConsentTests {
+    @Test("privacy default keeps uploads off")
+    func privacyDefault() {
+        let consent = DiagnosticsConsent.privacyDefault
+        #expect(consent.diagnosticsEnabled)
+        #expect(consent.remoteUploadEnabled == false)
+        #expect(consent.uploadEndpoint == nil)
+        #expect(consent.canUpload == false)
+    }
+
+    @Test("canUpload requires both the flag and an endpoint")
+    func canUpload() {
+        var consent = DiagnosticsConsent(diagnosticsEnabled: true, remoteUploadEnabled: true)
+        #expect(consent.canUpload == false)
+        consent.uploadEndpoint = URL(string: "https://capsule.example/v1/telemetry")
+        #expect(consent.canUpload)
+    }
+
+    @Test("consent round-trips through Codable")
+    func codable() throws {
+        let consent = DiagnosticsConsent(
+            diagnosticsEnabled: false,
+            remoteUploadEnabled: true,
+            uploadEndpoint: URL(string: "https://capsule.example")
+        )
+        let data = try JSONEncoder().encode(consent)
+        let decoded = try JSONDecoder().decode(DiagnosticsConsent.self, from: data)
+        #expect(decoded == consent)
+    }
+}

--- a/capsule-swift/Modules/CapsuleTestSupport/Sources/DiagnosticsMocks.swift
+++ b/capsule-swift/Modules/CapsuleTestSupport/Sources/DiagnosticsMocks.swift
@@ -1,0 +1,164 @@
+import CapsuleDiagnostics
+import CapsuleFoundation
+import Foundation
+import os
+
+/// A deterministic ``TimeSource`` for tests.
+public struct FixedTimeSource: TimeSource {
+    public let now: Date
+    public init(now: Date = Date(timeIntervalSince1970: 0)) { self.now = now }
+}
+
+/// A ``DiagnosticsSink`` that records every event it receives, for assertions.
+public final class MockDiagnosticsSink: DiagnosticsSink {
+    private let storage = OSAllocatedUnfairLock<[DiagnosticEvent]>(initialState: [])
+    public init() {}
+
+    public func record(_ event: DiagnosticEvent, at _: Date) {
+        storage.withLock { $0.append(event) }
+    }
+
+    /// Every event recorded so far, in order.
+    public var recorded: [DiagnosticEvent] { storage.withLock { $0 } }
+}
+
+/// A settable ``ConsentReading`` for tests, with a `send(_:)` hook to drive
+/// runtime consent changes through ``changes()``.
+public actor MockConsentReading: ConsentReading {
+    private var consent: DiagnosticsConsent
+    private var continuation: AsyncStream<DiagnosticsConsent>.Continuation?
+
+    public init(_ consent: DiagnosticsConsent = .privacyDefault) {
+        self.consent = consent
+    }
+
+    public func current() -> DiagnosticsConsent { consent }
+
+    public nonisolated func changes() -> AsyncStream<DiagnosticsConsent> {
+        AsyncStream { continuation in
+            Task { await self.attach(continuation) }
+        }
+    }
+
+    /// Update the value and notify observers.
+    public func send(_ consent: DiagnosticsConsent) {
+        self.consent = consent
+        continuation?.yield(consent)
+    }
+
+    /// Replays the latest value on subscribe (CurrentValueSubject semantics) so
+    /// observers always converge on the newest consent regardless of timing.
+    private func attach(_ continuation: AsyncStream<DiagnosticsConsent>.Continuation) {
+        self.continuation = continuation
+        continuation.yield(consent)
+    }
+}
+
+/// A ``LogExcerptReader`` returning a fixed set of (possibly unredacted) entries.
+public struct MockLogExcerptReader: LogExcerptReader {
+    private let entries: [DiagnosticsBundle.LogEntry]
+    public init(_ entries: [DiagnosticsBundle.LogEntry]) { self.entries = entries }
+
+    public func recentEntries(within _: TimeInterval, limit: Int) async -> [DiagnosticsBundle.LogEntry] {
+        Array(entries.prefix(limit))
+    }
+}
+
+/// A ``DiagnosticsExporter`` returning a fixed bundle and recording its inputs.
+public actor MockDiagnosticsExporter: DiagnosticsExporter {
+    public private(set) var lastBreadcrumbs: [BreadcrumbRing.Breadcrumb] = []
+    public private(set) var lastCrash: CrashSummary?
+    private let bundle: DiagnosticsBundle
+
+    public init(returning bundle: DiagnosticsBundle) { self.bundle = bundle }
+
+    public func exportBundle(
+        metadata _: DeviceMetadata,
+        breadcrumbs: [BreadcrumbRing.Breadcrumb],
+        crash: CrashSummary?
+    ) -> DiagnosticsBundle {
+        lastBreadcrumbs = breadcrumbs
+        lastCrash = crash
+        return bundle
+    }
+}
+
+/// A ``TelemetryUploader`` that records attempts and can be configured to fail a
+/// number of times before succeeding.
+public final class MockTelemetryUploader: TelemetryUploader {
+    private struct State {
+        var attempts: [URL] = []
+        var remainingFailures: Int
+    }
+
+    private let state: OSAllocatedUnfairLock<State>
+
+    public init(failuresBeforeSuccess: Int = 0) {
+        state = OSAllocatedUnfairLock(initialState: State(remainingFailures: failuresBeforeSuccess))
+    }
+
+    public func upload(_: DiagnosticsBundle, to endpoint: URL) async throws {
+        try state.withLock { state in
+            state.attempts.append(endpoint)
+            if state.remainingFailures > 0 {
+                state.remainingFailures -= 1
+                throw UploadError.server(status: 500)
+            }
+        }
+    }
+
+    /// The number of upload attempts made.
+    public var uploadCount: Int { state.withLock { $0.attempts.count } }
+}
+
+/// A ``MetricsCollecting`` recording start/stop, so consent-gating can be tested
+/// without registering a real `MXMetricManager` subscriber.
+public final class MockMetricsCollector: MetricsCollecting, @unchecked Sendable {
+    private struct Counts {
+        var started = false
+        var startCount = 0
+        var stopCount = 0
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: Counts())
+    public init() {}
+
+    public func start() { state.withLock { $0.started = true; $0.startCount += 1 } }
+    public func stop() { state.withLock { $0.started = false; $0.stopCount += 1 } }
+
+    public var isStarted: Bool { state.withLock { $0.started } }
+    public var startCount: Int { state.withLock { $0.startCount } }
+    public var stopCount: Int { state.withLock { $0.stopCount } }
+}
+
+/// A ``UploadTransport`` that fails a configurable number of times before
+/// returning a success status, recording every send.
+public final class MockUploadTransport: UploadTransport {
+    private struct State {
+        var sends = 0
+        var remainingFailures: Int
+        var successStatus: Int
+    }
+
+    private let state: OSAllocatedUnfairLock<State>
+
+    public init(failuresBeforeSuccess: Int = 0, successStatus: Int = 200) {
+        state = OSAllocatedUnfairLock(
+            initialState: State(remainingFailures: failuresBeforeSuccess, successStatus: successStatus)
+        )
+    }
+
+    public func send(_: URLRequest) async throws -> Int {
+        try state.withLock { state in
+            state.sends += 1
+            if state.remainingFailures > 0 {
+                state.remainingFailures -= 1
+                throw UploadError.server(status: 503)
+            }
+            return state.successStatus
+        }
+    }
+
+    /// The number of send attempts made.
+    public var sendCount: Int { state.withLock { $0.sends } }
+}

--- a/capsule-swift/Modules/FeatureTimeline/Sources/TimelineViewModel.swift
+++ b/capsule-swift/Modules/FeatureTimeline/Sources/TimelineViewModel.swift
@@ -87,6 +87,7 @@ public final class TimelineViewModel {
     /// Request access and load the timeline. Safe to call once, on appear.
     public func load() async {
         let status = await provider.requestAuthorization()
+        Diagnostics.shared.record(.photoPermission(granted: status.isUsable))
         guard status.isUsable else {
             state = .needsAuthorization
             return
@@ -138,6 +139,7 @@ public final class TimelineViewModel {
             state = .ready
         } catch {
             CapsuleLog.interface.error("timeline load failed: \(String(describing: error), privacy: .public)")
+            Diagnostics.shared.recordError(operation: .timelineLoad)
             state = .failed("Couldn't load your photo library.")
         }
     }

--- a/capsule-swift/Modules/ManagedStore/Sources/ImportService.swift
+++ b/capsule-swift/Modules/ManagedStore/Sources/ImportService.swift
@@ -42,6 +42,7 @@ public actor ImportService {
             catalog = try await library.catalog()
         } catch {
             CapsuleLog.managedStore.error("import aborted, catalog unavailable: \(String(describing: error), privacy: .public)")
+            Diagnostics.shared.recordError(operation: .importRun)
             return ImportResult(failures: sources.map {
                 ImportFailure(filename: $0.originalFilename, reason: "Library unavailable.")
             })

--- a/capsule-swift/Project.swift
+++ b/capsule-swift/Project.swift
@@ -77,6 +77,14 @@ private let moduleTargets: [Target] =
     // Foundation — value types, logging, utilities. No dependencies.
     module("CapsuleFoundation", testDependencies: [])
 
+        // Diagnostics — MetricKit crash/perf collection, consent, breadcrumbs,
+        // redacted bug-report bundles, and an opt-in self-hosted uploader.
+        + module(
+            "CapsuleDiagnostics",
+            dependencies: [.target(name: "CapsuleFoundation")],
+            testDependencies: [supportDependency]
+        )
+
         // Catalog — Swift adapter over the Rust UniFFI catalog. Compiles the
         // generated bindings and links the prebuilt xcframework.
         + module(
@@ -117,6 +125,7 @@ private let moduleTargets: [Target] =
             "CapsuleTestSupport",
             dependencies: [
                 .target(name: "CapsuleFoundation"),
+                .target(name: "CapsuleDiagnostics"),
                 .target(name: "CapsuleCatalog"),
                 .target(name: "ManagedStore"),
                 .target(name: "AssetKit"),
@@ -202,6 +211,7 @@ private let appTarget: Target = .target(
             "Capsule shows and organizes the photos and videos in your library.",
     ]),
     sources: ["App/iOS/Sources/**"],
+    resources: ["App/iOS/Resources/**"],
     dependencies: [
         .target(name: "FeatureTimeline"),
         .target(name: "FeatureViewer"),
@@ -210,6 +220,7 @@ private let appTarget: Target = .target(
         .target(name: "CapsuleUI"),
         .target(name: "ImagePipeline"),
         .target(name: "AssetKit"),
+        .target(name: "CapsuleDiagnostics"),
         .target(name: "CapsuleFoundation"),
     ],
     settings: appSettings
@@ -218,6 +229,7 @@ private let appTarget: Target = .target(
 /// Every unit-test target — gathered for the `Capsule` scheme's test action.
 private let testTargetNames: [TestableTarget] = [
     "CapsuleFoundationTests",
+    "CapsuleDiagnosticsTests",
     "CapsuleCatalogTests",
     "ManagedStoreTests",
     "AssetKitTests",


### PR DESCRIPTION
## Summary

Closes #10 — sets up the SwiftUI app (`capsule-swift`) with telemetry, crash/diagnostics, and bug reporting for a production-grade mobile app.

Implemented as a **first-party, consent-gated, privacy-first** observability layer — **no third-party SDK** — consistent with the project's hermetic build (zero SPM deps) and its E2E-encrypted / self-hostable posture. Per product decisions: **diagnostics only** (no product-usage analytics), **opt-in self-hosted uploader** (shipped disabled, no `capsule-api` changes), and a **local-only default** (on-device diagnostics on; any upload strictly opt-in).

## What's included

- **`CapsuleFoundation` (emit API, zero new dependency for callers):** typed, PII-free `DiagnosticEvent`, `DiagnosticsSink` + `OSLogDiagnosticsSink`, the `Diagnostics.shared` facade, `DiagnosticsConsent`, and a `TimeSource`. Features emit exactly like they use `CapsuleLog`.
- **`CapsuleDiagnostics` (new module):** Apple **MetricKit** subscriber (crash / hang / CPU / disk-write diagnostics + performance metrics — the privacy-safe, OS-symbolicated path, no async-signal-unsafe in-process handler), `ConsentStore`, `BreadcrumbRing`, `LastWordsStore` (clean-shutdown sentinel), `OSLogStore` export with **redaction**, `DiagnosticsBundle`, an opt-in `RemoteTelemetryUploader` (URLSession behind a testable transport), and the `DiagnosticsCoordinator` that reconciles sinks to consent live.
- **App:** a **Settings** tab (consent toggles + endpoint field + "Report a Problem" via the system share sheet), a **crashed-last-launch** prompt, scene-phase clean-shutdown tracking, and instrumentation of the timeline / import / photo-permission paths.
- **`PrivacyInfo.xcprivacy`** privacy manifest — `NSPrivacyTracking=false`, required-reason API declarations (UserDefaults `CA92.1`, disk space `E174.1`, file timestamp `C617.1`); verified bundled at the app root.

## Privacy posture

- On-device diagnostics (MetricKit + OSLog) are **on by default** and never leave the device.
- Product analytics: **none**. Bug reports are redacted (no photos, asset IDs, paths, or device identifiers) and shared via the OS share sheet.
- Network upload to a self-hosted endpoint is **off by default** and requires explicit opt-in.

## Tests & verification

- Contract-first **Swift Testing**: **37 new tests** — consent gating, redaction/no-PII (planted secrets never appear in the serialized bundle), breadcrumb eviction, uploader retry/backoff, persisted stores, disk buckets, Codable round-trips.
- `xcodebuild test` (iPhone 16 Pro sim): **all suites pass**. Debug **and** Release builds succeed. `swiftformat --lint` and `swiftlint --strict` clean (0 violations).
- **MetricKit caveat:** real crash/diagnostic payloads arrive on the next launch and aren't synthesized by the simulator; the subscriber is unit-tested via a `MetricsCollecting` seam, with end-to-end crash verification requiring a device build.

## Out of scope (intentional)

Product-usage analytics; a `capsule-api` telemetry endpoint (uploader ships disabled); a general networking layer; third-party SDKs; a standalone `FeatureSettings` module; automated crash injection in CI.