### PR TITLE
feat(core): AI-tag containment ops + ai_tags query cache

### DIFF
--- a/capsule-core/src/db/driver.rs
+++ b/capsule-core/src/db/driver.rs
@@ -1,4 +1,4 @@
-use crate::db::rows::{AssetRow, AssetStackRow, CachedRepresentationRow, StackMemberRow};
+use crate::db::rows::{AiTagRow, AssetRow, AssetStackRow, CachedRepresentationRow, StackMemberRow};
 use crate::db::schema;
 use rusqlite::{Connection, params};
 use std::path::Path;
@@ -352,6 +352,40 @@ impl DatabaseDriver {
         let rows = stmt.query_map(params![uuid], |r| r.get::<_, String>(0))?;
         rows.collect()
     }
+
+    // ── AI tags (ai_tags index — structurally separate from user tags) ────────────
+
+    /// Replace the indexed AI tags for `uuid` with `rows` (the asset's current `tags_ai` value).
+    /// A projection of the sidecar OR-set; the sidecar remains the source of truth.
+    pub fn replace_ai_tags(&self, uuid: &str, rows: &[AiTagRow]) -> Result<(), rusqlite::Error> {
+        self.conn
+            .execute("DELETE FROM ai_tags WHERE uuid = ?1", params![uuid])?;
+        for row in rows {
+            self.conn.execute(
+                "INSERT OR IGNORE INTO ai_tags (uuid, tag, model_id, model_version) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![row.uuid, row.tag, row.model_id, row.model_version],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// The indexed AI tags for `uuid`, ordered by tag then model.
+    pub fn ai_tags_for(&self, uuid: &str) -> Result<Vec<AiTagRow>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT uuid, tag, model_id, model_version FROM ai_tags \
+             WHERE uuid = ?1 ORDER BY tag, model_id",
+        )?;
+        let rows = stmt.query_map(params![uuid], |r| {
+            Ok(AiTagRow {
+                uuid: r.get(0)?,
+                tag: r.get(1)?,
+                model_id: r.get(2)?,
+                model_version: r.get(3)?,
+            })
+        })?;
+        rows.collect()
+    }
 }
 
 fn now_secs() -> i64 {
@@ -431,7 +465,7 @@ mod tests {
     fn test_init_schema_idempotent() {
         let db = DatabaseDriver::open_in_memory().unwrap();
         db.init_schema().unwrap(); // second call — should not fail
-        assert_eq!(db.schema_version().unwrap(), 3);
+        assert_eq!(db.schema_version().unwrap(), 4);
     }
 
     #[test]

--- a/capsule-core/src/db/mod.rs
+++ b/capsule-core/src/db/mod.rs
@@ -4,5 +4,7 @@ pub mod schema;
 pub mod vector;
 
 pub use driver::DatabaseDriver;
-pub use rows::{AssetRow, AssetStackRow, AssetTagRow, CachedRepresentationRow, StackMemberRow};
+pub use rows::{
+    AiTagRow, AssetRow, AssetStackRow, AssetTagRow, CachedRepresentationRow, StackMemberRow,
+};
 pub use vector::{EmbeddingInsert, EmbeddingRecord, KnnHit, VectorIndexError};

--- a/capsule-core/src/db/rows.rs
+++ b/capsule-core/src/db/rows.rs
@@ -48,6 +48,18 @@ pub struct AssetTagRow {
     pub tag: String,
 }
 
+/// One AI-suggested tag, projected from the sidecar's `tags_ai` OR-set into the queryable index.
+/// Kept in a separate table from user tags ([`AssetTagRow`]) — the AI/user namespace separation
+/// is structural, so an AI tag can never collide with a user tag. Carries its embedding-provenance
+/// `(model_id, model_version)` so stale entries (a superseded model version) are identifiable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AiTagRow {
+    pub uuid: String,
+    pub tag: String,
+    pub model_id: String,
+    pub model_version: String,
+}
+
 /// One cached, reclaimable representation of an asset. The eviction sweep ranks these by
 /// `last_accessed_at` (LRU) with `tier` as the tiebreaker; `pinned` and `is_owned_original`
 /// rows are exempt. `path` is the on-disk cache file the sweep deletes.

--- a/capsule-core/src/db/schema.rs
+++ b/capsule-core/src/db/schema.rs
@@ -1,4 +1,4 @@
-pub const SCHEMA_VERSION: u32 = 3;
+pub const SCHEMA_VERSION: u32 = 4;
 
 pub const DDL: &str = r#"
 PRAGMA journal_mode = WAL;
@@ -50,6 +50,21 @@ CREATE TABLE IF NOT EXISTS asset_tags (
     tag   TEXT NOT NULL,
     PRIMARY KEY (uuid, tag)
 );
+
+-- AI-suggested tags, projected from the sidecar `tags_ai` OR-set. A structurally separate table
+-- from user tags: AI output lands in its own namespace and can never collide with or overwrite a
+-- user tag. Each row carries its embedding-provenance (model_id, model_version) so a superseded
+-- model version is identifiable. Derived from the sidecar (SSoT); re-synced on every edit.
+-- SSoT: design/metadata § Tag Provenance and Namespacing, design/ai § AI Output Containment.
+CREATE TABLE IF NOT EXISTS ai_tags (
+    uuid          TEXT NOT NULL,
+    tag           TEXT NOT NULL,
+    model_id      TEXT NOT NULL,
+    model_version TEXT NOT NULL,
+    PRIMARY KEY (uuid, tag, model_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_tags_tag ON ai_tags(tag);
 
 CREATE INDEX IF NOT EXISTS idx_assets_hash       ON assets(hash_sha256);
 CREATE INDEX IF NOT EXISTS idx_assets_utc        ON assets(capture_utc, capture_timestamp);

--- a/capsule-core/src/library/init.rs
+++ b/capsule-core/src/library/init.rs
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(ver.version, CURRENT_LIBRARY_VERSION);
 
         // SQLite has the correct schema version
-        assert_eq!(lib.db.schema_version().unwrap(), 3);
+        assert_eq!(lib.db.schema_version().unwrap(), 4);
 
         // Config has the correct library name
         assert_eq!(lib.config().library_name, "My Library");

--- a/capsule-core/src/lifecycle.rs
+++ b/capsule-core/src/lifecycle.rs
@@ -43,10 +43,11 @@ use crate::crypto::provenance::manifest::{ASSET_MANIFEST_VERSION, ManifestCore};
 use crate::crypto::provenance::{AssetManifest, ProvenanceChain, ProvenanceRecord};
 use crate::crypto::verify_asset::{VerifyOutcome, verify_asset};
 use crate::crypto::{CryptoError, authority::ReferenceAuthority};
-use crate::db::{AssetRow, CachedRepresentationRow, DatabaseDriver};
+use crate::db::{AiTagRow, AssetRow, CachedRepresentationRow, DatabaseDriver};
 use crate::library::Library;
 use crate::metadata::crdt::{AddId, Counter};
-use crate::sidecar::sidecar_v1::{SIDECAR_SCHEMA_V1, SidecarV1};
+use crate::ml::{ModelId, Registry};
+use crate::sidecar::sidecar_v1::{AiTag, SIDECAR_SCHEMA_V1, SidecarV1};
 
 /// A device is treated as added far in the past so any import timestamp postdates it.
 const DEVICE_ADDED_AT: &str = "2020-01-01T00:00:00Z";
@@ -410,10 +411,29 @@ impl Workspace {
             .db
             .upsert_asset(&asset_row_from_state(asset))
             .map_err(|e| LifecycleError::Db(e.to_string()))?;
+        let uuid = asset.asset_id.to_string();
         let tags: Vec<String> = asset.sidecar.tags_user.value().into_iter().collect();
         self.library
             .db
-            .replace_asset_tags(&asset.asset_id.to_string(), &tags)
+            .replace_asset_tags(&uuid, &tags)
+            .map_err(|e| LifecycleError::Db(e.to_string()))?;
+        // Project the structurally-separate AI tags into their own index table (the sidecar
+        // OR-set stays the source of truth; this is a rebuildable query cache).
+        let ai_rows: Vec<AiTagRow> = asset
+            .sidecar
+            .tags_ai
+            .value()
+            .into_iter()
+            .map(|t| AiTagRow {
+                uuid: uuid.clone(),
+                tag: t.tag,
+                model_id: t.model_id,
+                model_version: t.model_version,
+            })
+            .collect();
+        self.library
+            .db
+            .replace_ai_tags(&uuid, &ai_rows)
             .map_err(|e| LifecycleError::Db(e.to_string()))
     }
 
@@ -564,7 +584,7 @@ impl Workspace {
         asset_id: &Uuid,
         action: Action,
         retention_until: Option<String>,
-        mutate_sidecar: impl FnOnce(&mut SidecarV1, AddId),
+        mutate_sidecar: impl FnOnce(&mut SidecarV1, &mut Counter),
     ) -> Result<()> {
         let album_id = self
             .assets
@@ -582,9 +602,10 @@ impl Workspace {
             .clone();
         let album = self.album(&album_id)?;
         let manifest = self.sign_lifecycle(album, &base, action, prior, retention_until);
-        let add_id = self.counter.issue();
 
         {
+            // Disjoint field borrows: the asset's state and the device counter. The closure may
+            // issue several `add_id`s (e.g. one per AI tag added in this single update).
             let asset = self.assets.get_mut(asset_id).unwrap();
             asset
                 .chain
@@ -595,7 +616,7 @@ impl Workspace {
                 })
                 .map_err(|e| LifecycleError::Cbor(format!("chain: {e}")))?;
             let new_head = asset.chain.head().unwrap();
-            mutate_sidecar(&mut asset.sidecar, add_id);
+            mutate_sidecar(&mut asset.sidecar, &mut self.counter);
             asset.sidecar.provenance_chain_hash = new_head;
             asset.sidecar.signature = None;
             asset.sidecar.sign(&self.account.user_ik);
@@ -612,8 +633,8 @@ impl Workspace {
     /// Add a user tag (OR-set) and emit a `metadata-update` provenance record.
     pub fn tag_add(&mut self, asset_id: &Uuid, tag: &str) -> Result<()> {
         let tag = tag.to_string();
-        self.append_lifecycle(asset_id, Action::MetadataUpdate, None, move |s, add_id| {
-            s.tags_user.add(tag, add_id);
+        self.append_lifecycle(asset_id, Action::MetadataUpdate, None, move |s, counter| {
+            s.tags_user.add(tag, counter.issue());
         })
     }
 
@@ -622,9 +643,115 @@ impl Workspace {
         let caption = caption.to_string();
         let device = self.account.device.device_id;
         let ts = now_rfc3339();
-        self.append_lifecycle(asset_id, Action::MetadataUpdate, None, move |s, _add_id| {
-            s.caption.set(caption, ts, device);
+        self.append_lifecycle(
+            asset_id,
+            Action::MetadataUpdate,
+            None,
+            move |s, _counter| {
+                s.caption.set(caption, ts, device);
+            },
+        )
+    }
+
+    // ── AI metadata containment (SSoT: metadata § Tag Provenance, ai § AI Output Containment) ──
+
+    /// Add AI-suggested tags to the asset's `tags_ai` OR-set — a namespace **structurally**
+    /// separate from `tags_user`, so an AI suggestion can never overwrite a user tag. Emits one
+    /// `metadata-update`; each tag gets a fresh `add_id` so it can later be dismissed individually.
+    /// A no-op (no record) if `tags` is empty.
+    pub fn add_ai_tags(&mut self, asset_id: &Uuid, tags: Vec<AiTag>) -> Result<()> {
+        if tags.is_empty() {
+            return Ok(());
+        }
+        self.append_lifecycle(asset_id, Action::MetadataUpdate, None, move |s, counter| {
+            for tag in tags {
+                s.tags_ai.add(tag, counter.issue());
+            }
         })
+    }
+
+    /// The asset's current AI tags paired with their `add_id`s — the surface a client uses to
+    /// dismiss or promote a specific suggestion.
+    pub fn ai_tags(&self, asset_id: &Uuid) -> Result<Vec<(AddId, AiTag)>> {
+        Ok(self
+            .assets
+            .get(asset_id)
+            .ok_or_else(|| LifecycleError::NotFound(format!("asset {asset_id}")))?
+            .sidecar
+            .tags_ai
+            .entries())
+    }
+
+    /// Dismiss an AI tag: an OR-set remove on `tags_ai` keyed by its `add_id`, emitting a
+    /// `metadata-update`. Rejects an `add_id` never observed locally (a fabricated remove) rather
+    /// than silently no-oping.
+    pub fn dismiss_ai_tag(&mut self, asset_id: &Uuid, add_id: AddId) -> Result<()> {
+        let observed = self
+            .assets
+            .get(asset_id)
+            .ok_or_else(|| LifecycleError::NotFound(format!("asset {asset_id}")))?
+            .sidecar
+            .tags_ai
+            .observed(&add_id);
+        if !observed {
+            return Err(LifecycleError::NotFound(format!(
+                "unobserved ai-tag add_id {add_id:?}"
+            )));
+        }
+        self.append_lifecycle(
+            asset_id,
+            Action::MetadataUpdate,
+            None,
+            move |s, _counter| {
+                s.tags_ai
+                    .remove(add_id)
+                    .expect("add_id observed above; remove cannot fail");
+            },
+        )
+    }
+
+    /// Promote an AI tag to a user tag: copy its text into `tags_user` with a **fresh user-scoped
+    /// `add_id`**, leaving the AI entry intact (still independently dismissable). An explicit,
+    /// signed lifecycle operation — never automatic.
+    pub fn promote_ai_tag(&mut self, asset_id: &Uuid, tag: &str) -> Result<()> {
+        let present = self
+            .assets
+            .get(asset_id)
+            .ok_or_else(|| LifecycleError::NotFound(format!("asset {asset_id}")))?
+            .sidecar
+            .tags_ai
+            .value()
+            .iter()
+            .any(|t| t.tag == tag);
+        if !present {
+            return Err(LifecycleError::NotFound(format!("ai tag '{tag}'")));
+        }
+        let tag = tag.to_string();
+        self.append_lifecycle(asset_id, Action::MetadataUpdate, None, move |s, counter| {
+            s.tags_user.add(tag, counter.issue());
+        })
+    }
+
+    /// The asset's AI tags that are **current** under `registry` — their `(model_id,
+    /// model_version)` is the canonical pair for the model's task. Stale suggestions (a superseded
+    /// model version) are excluded until regenerated, mirroring the vector-index stale rule. The
+    /// sidecar retains every AI tag regardless (it is the source of truth).
+    pub fn current_ai_tags(&self, registry: &Registry, asset_id: &Uuid) -> Result<Vec<AiTag>> {
+        let sidecar = &self
+            .assets
+            .get(asset_id)
+            .ok_or_else(|| LifecycleError::NotFound(format!("asset {asset_id}")))?
+            .sidecar;
+        Ok(sidecar
+            .tags_ai
+            .value()
+            .into_iter()
+            .filter(|t| {
+                registry
+                    .row_for_id(&ModelId::from(t.model_id.as_str()))
+                    .is_some_and(|row| row.canonical_version.as_str() == t.model_version)
+            })
+            .collect())
     }
 
     /// Soft-delete: emit a `delete` record carrying a signed retention window.
@@ -1001,5 +1128,137 @@ mod tests {
         assert!(ws.db().query_timeline(0, 100).unwrap().is_empty());
         ws.restore(&id).unwrap();
         assert_eq!(ws.db().query_timeline(0, 100).unwrap().len(), 1);
+    }
+
+    fn ws_with_asset(lib: &TempDir, src: &TempDir) -> (Workspace, Uuid) {
+        let img = src.path().join("p.jpg");
+        fs::write(&img, b"\xFF\xD8\xFF ai containment test bytes \x00\x01").unwrap();
+        let mut ws = fast_workspace(lib.path());
+        let album = ws.create_album("A");
+        let id = ws.import_asset(album, &img).unwrap();
+        (ws, id)
+    }
+
+    fn ai(tag: &str) -> AiTag {
+        AiTag {
+            tag: tag.into(),
+            model_id: "mobileclip-b".into(),
+            model_version: "1".into(),
+        }
+    }
+
+    #[test]
+    fn ai_tags_live_in_a_separate_namespace_and_promotion_is_explicit() {
+        let (lib, src) = (TempDir::new().unwrap(), TempDir::new().unwrap());
+        let (mut ws, id) = ws_with_asset(&lib, &src);
+        let uuid = id.to_string();
+
+        ws.add_ai_tags(&id, vec![ai("beach"), ai("sunset")])
+            .unwrap();
+
+        // AI tags land in tags_ai, never tags_user.
+        let st = ws.asset(&id).unwrap();
+        assert!(st.sidecar.tags_user.value().is_empty());
+        let ai_vals: Vec<_> = st
+            .sidecar
+            .tags_ai
+            .value()
+            .into_iter()
+            .map(|t| t.tag)
+            .collect();
+        assert!(ai_vals.contains(&"beach".to_string()) && ai_vals.contains(&"sunset".to_string()));
+        // The DB projects them into the separate ai_tags table; asset_tags stays empty.
+        assert!(ws.db().tags_for(&uuid).unwrap().is_empty());
+        assert_eq!(ws.db().ai_tags_for(&uuid).unwrap().len(), 2);
+
+        // Promote "beach" → a user tag with a FRESH user-scoped add_id; AI entry remains.
+        let beach_ai_add_id = ws
+            .ai_tags(&id)
+            .unwrap()
+            .into_iter()
+            .find(|(_, t)| t.tag == "beach")
+            .unwrap()
+            .0;
+        ws.promote_ai_tag(&id, "beach").unwrap();
+
+        let st = ws.asset(&id).unwrap();
+        assert!(st.sidecar.tags_user.value().contains("beach"));
+        let beach_user_add_id = st
+            .sidecar
+            .tags_user
+            .entries()
+            .into_iter()
+            .find(|(_, t)| t.as_str() == "beach")
+            .unwrap()
+            .0;
+        assert_ne!(
+            beach_user_add_id, beach_ai_add_id,
+            "promotion mints a fresh user-scoped add_id, not the AI tag's"
+        );
+        // The AI entry is untouched and still independently present.
+        assert!(st.sidecar.tags_ai.value().iter().any(|t| t.tag == "beach"));
+        assert_eq!(ws.db().tags_for(&uuid).unwrap(), vec!["beach".to_string()]);
+        assert_eq!(ws.db().ai_tags_for(&uuid).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn dismiss_ai_tag_removes_by_add_id_and_rejects_unobserved() {
+        let (lib, src) = (TempDir::new().unwrap(), TempDir::new().unwrap());
+        let (mut ws, id) = ws_with_asset(&lib, &src);
+        ws.add_ai_tags(&id, vec![ai("beach"), ai("sunset")])
+            .unwrap();
+
+        let beach_id = ws
+            .ai_tags(&id)
+            .unwrap()
+            .into_iter()
+            .find(|(_, t)| t.tag == "beach")
+            .unwrap()
+            .0;
+        ws.dismiss_ai_tag(&id, beach_id).unwrap();
+
+        let remaining: Vec<_> = ws
+            .asset(&id)
+            .unwrap()
+            .sidecar
+            .tags_ai
+            .value()
+            .into_iter()
+            .map(|t| t.tag)
+            .collect();
+        assert_eq!(remaining, vec!["sunset".to_string()]);
+        assert_eq!(ws.db().ai_tags_for(&id.to_string()).unwrap().len(), 1);
+
+        // A fabricated add_id (never observed) is rejected, not silently no-oped.
+        let bogus = AddId {
+            device: Uuid::from_u128(0xBAD),
+            counter: 999,
+        };
+        assert!(ws.dismiss_ai_tag(&id, bogus).is_err());
+    }
+
+    #[test]
+    fn ai_tags_are_provenance_tracked_and_stale_excluded_after_version_bump() {
+        let (lib, src) = (TempDir::new().unwrap(), TempDir::new().unwrap());
+        let (mut ws, id) = ws_with_asset(&lib, &src);
+        let before = ws.asset(&id).unwrap().chain.records().len();
+
+        ws.add_ai_tags(&id, vec![ai("beach")]).unwrap();
+        // Emitted exactly one metadata-update provenance record.
+        let st = ws.asset(&id).unwrap();
+        assert_eq!(st.chain.records().len(), before + 1);
+        assert_eq!(
+            st.chain.records().last().unwrap().manifest.core.action,
+            Action::MetadataUpdate
+        );
+
+        // Current under the canonical registry...
+        let mut reg = Registry::canonical();
+        assert_eq!(ws.current_ai_tags(&reg, &id).unwrap().len(), 1);
+        // ...but a model swap (version bump) flags it stale → excluded from the current surface,
+        // while the sidecar still retains it (source of truth).
+        reg.set_canonical_version(crate::ml::TaskKind::SemanticSearch, "2".into());
+        assert!(ws.current_ai_tags(&reg, &id).unwrap().is_empty());
+        assert_eq!(ws.asset(&id).unwrap().sidecar.tags_ai.value().len(), 1);
     }
 }

--- a/capsule-core/src/metadata/crdt/or_set.rs
+++ b/capsule-core/src/metadata/crdt/or_set.rs
@@ -91,6 +91,17 @@ impl<T: Ord + Clone> OrSet<T> {
     pub fn observed(&self, add_id: &AddId) -> bool {
         self.adds.contains_key(add_id)
     }
+
+    /// The live `(add_id, element)` pairs — those not tombstoned. Unlike [`value`](Self::value)
+    /// this preserves each element's `add_id`, so a caller can surface elements (e.g. AI tags) and
+    /// later target a specific one by `add_id` (dismiss, promote).
+    pub fn entries(&self) -> Vec<(AddId, T)> {
+        self.adds
+            .iter()
+            .filter(|(id, _)| !self.removes.contains(id))
+            .map(|(id, el)| (*id, el.clone()))
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -179,6 +190,17 @@ mod tests {
         let before = left.clone();
         left.merge(&b);
         assert_eq!(left, before);
+    }
+
+    #[test]
+    fn entries_expose_live_add_ids_and_drop_tombstoned() {
+        let mut s: OrSet<String> = OrSet::new();
+        s.add("a".into(), id(1, 0));
+        s.add("b".into(), id(1, 1));
+        s.remove(id(1, 0)).unwrap();
+        let entries = s.entries();
+        // Only the live element survives, and it carries its add_id.
+        assert_eq!(entries, vec![(id(1, 1), "b".to_string())]);
     }
 
     #[test]


### PR DESCRIPTION
## What

Third PR in the **on-device ML stack** (stacked on #336). Implements the AI/user metadata **namespace separation** — the structural defense from `ai.md`'s *AI Output Containment* and `metadata.md`'s *Tag Provenance and Namespacing* — as lifecycle operations, backed by a separate `ai_tags` index table.

`Workspace` ops (each a provenance-tracked `metadata-update`):
- **`add_ai_tags`** — write to the `tags_ai` OR-set; one record, a fresh `add_id` per tag. Never touches `tags_user`.
- **`dismiss_ai_tag(add_id)`** — OR-set remove by `add_id`; **rejects an unobserved (fabricated) `add_id`** rather than silently no-oping.
- **`promote_ai_tag(text)`** — copies the text into `tags_user` with a **fresh user-scoped `add_id`**, leaving the AI entry intact. Explicit and signed; never automatic.
- **`ai_tags` / `current_ai_tags`** — surface AI tags with their `add_id`s; `current_ai_tags` excludes entries whose `model_version` is **stale** under the registry (mirrors the PR #336 vector-index rule).

## Design conformance

- **Structural separation** (`ai.md#ai-output-containment`, `metadata.md#tag-provenance-and-namespacing`): `tags_ai` and `tags_user` are different fields — an AI tag can never overwrite a user tag. The DB mirrors this with separate `asset_tags` / `ai_tags` tables.
- **Namespace-separation validation bullet** (`ai.md#validation`): promotion yields a fresh user-scoped `add_id`; the AI entry remains separately editable.
- **Add-id rejection** (`metadata.md`): dismissing an unobserved `add_id` is refused (reuses `OrSet`'s observed-remove guard).
- `ai_tags` is a **rebuildable query cache**; the signed sidecar OR-set remains the source of truth.

## Notable refactor

`append_lifecycle`'s mutation closure now receives `&mut Counter` (not a single `AddId`) via a disjoint field borrow, so one `metadata-update` can mint several `add_id`s (a batch of AI tags). `OrSet` gains `entries()` for `(add_id, element)` surfacing. Schema → v4.

## Testing

3 lifecycle tests (separate-namespace + explicit promotion with fresh add_id; dismiss-by-add_id + unobserved rejection; provenance-tracked + stale-excluded-after-version-bump) + 1 `OrSet::entries` test. Full `cargo test -p capsule-core` → **300 passed**. `clippy --workspace --exclude capsule-sdk -D warnings` + `fmt --check` clean.

## Stack
#335 ← #336 ← **this** ← embedding-derivative provenance ← orchestration + ModelRunner ← regeneration + E2E.