### PR TITLE
feat(core): ML orchestration + ModelRunner seam + FixtureRunner

### DIFF
--- a/capsule-core/src/ml/mod.rs
+++ b/capsule-core/src/ml/mod.rs
@@ -1,23 +1,36 @@
 //! On-device ML orchestration and the canonical model inventory (SSoT: [AI/ML Integrations]).
 //!
-//! This module owns the *structure* the AI design fixes — independent of which model actually
-//! runs:
-//!
-//! - the [`registry`] — the canonical model inventory (one row per task) and the
+//! - [`registry`] — the canonical model inventory (one row per task) and the
 //!   **embedding-provenance invariant** (every embedding carries `(model_id, model_version)`;
-//!   the vector index refuses non-canonical inserts; a version bump flags old entries stale);
+//!   the vector index refuses non-canonical inserts; a version bump flags old entries stale).
+//! - [`runner`] — the [`ModelRunner`] inference seam and a deterministic [`FixtureRunner`] for
+//!   tests. Real per-platform runners are a default-off, weight-fetching feature; this mirrors
+//!   [`AlbumAuthority`](crate::crypto::authority::AlbumAuthority) /
+//!   [`ReferenceAuthority`](crate::crypto::authority::ReferenceAuthority) standing in for live MLS.
+//! - [`orchestrator`] — runs the canonical model over an asset and writes results back through the
+//!   signed lifecycle (embeddings, zero-shot AI tags), plus the device-bound batching/thermal
+//!   policy and natural-language search.
+//! - [`video`] — video-as-sparse-photos keyframe selection.
+//! - [`reid`] — re-identification & pseudo-labeling geometry/vector math.
 //!
-//! Real per-platform inference is deferred behind a `ModelRunner` seam (a later PR), exactly as
-//! live MLS group state is deferred behind
-//! [`AlbumAuthority`](crate::crypto::authority::AlbumAuthority) with `ReferenceAuthority` standing
-//! in. The portable runner is a default-off, weight-fetching feature of this crate; the local
-//! vector index lives in [`crate::db`]. No model weights are committed to this repository.
+//! The local vector index lives in [`crate::db`]. No model weights are committed to this repo.
 //!
 //! [AI/ML Integrations]: https://docs/design/ai/
 
+pub mod orchestrator;
 pub mod registry;
+pub mod reid;
+pub mod runner;
+pub mod video;
 
+pub use orchestrator::{
+    BatchMode, OrchestratorError, auto_tag, choose_batch_mode, embed_and_store, micro_batch_size,
+    semantic_search, should_pause_for_heat,
+};
 pub use registry::{
     DistanceMetric, EmbeddingDim, ModelId, ModelRow, ModelVersion, Registry, RegistryError,
     TaskKind, TaskOutput,
 };
+pub use reid::{cosine_sim, iou, links_to_profile, pseudo_labels};
+pub use runner::{BBox, Detection, Embedding, FixtureRunner, Frame, ModelRunner, RunnerError};
+pub use video::{Keyframe, Scene, reject_blurry, sample_keyframes};

--- a/capsule-core/src/ml/orchestrator.rs
+++ b/capsule-core/src/ml/orchestrator.rs
@@ -1,0 +1,312 @@
+//! Inference orchestration (SSoT: [AI/ML Integrations]).
+//!
+//! Ties a [`ModelRunner`] to the [`Workspace`]: run the canonical model over an asset, then write
+//! the results back through the signed lifecycle — embeddings as [embedding
+//! derivatives](Workspace::add_embedding_derivative), zero-shot tags as
+//! [AI tags](Workspace::add_ai_tags). Embeddings are reused for zero-shot classification, so no
+//! separate classifier is needed. Also the device-bound execution policy: horizontal vs. vertical
+//! batching by RAM, the micro-batch ceiling, and the thermal-throttle pause.
+//!
+//! The embedding-provenance invariant is enforced at this boundary: a runner whose declared model
+//! is not the registry canonical for a task is refused before any output is stored.
+//!
+//! [AI/ML Integrations]: https://docs/design/ai/
+
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::db::KnnHit;
+use crate::lifecycle::{LifecycleError, Workspace};
+use crate::ml::reid::cosine_sim;
+use crate::ml::runner::{Frame, ModelRunner, RunnerError};
+use crate::ml::{ModelId, Registry, TaskKind};
+use crate::sidecar::sidecar_v1::AiTag;
+
+/// Failures from orchestrating inference.
+#[derive(Debug, Error)]
+pub enum OrchestratorError {
+    /// A lifecycle write failed.
+    #[error(transparent)]
+    Lifecycle(#[from] LifecycleError),
+    /// The runner failed.
+    #[error(transparent)]
+    Runner(#[from] RunnerError),
+    /// A vector-index query failed.
+    #[error(transparent)]
+    Vector(#[from] crate::db::VectorIndexError),
+    /// The task has no canonical model (or is not an embedding task where one is required).
+    #[error("task {task:?} has no canonical embedding model")]
+    NoCanonical {
+        /// The task.
+        task: TaskKind,
+    },
+    /// The runner's declared model is not the registry canonical for the task — its outputs are
+    /// refused rather than stored under a canonical tuple they did not produce.
+    #[error("runner model `{declared}` is not canonical for task {task:?}")]
+    NonCanonicalRunner {
+        /// The task.
+        task: TaskKind,
+        /// The runner's declared model id.
+        declared: ModelId,
+    },
+}
+
+/// Confirm `runner` produces the registry's canonical `(model_id, model_version)` for `task`.
+fn require_canonical_runner<R: ModelRunner>(
+    runner: &R,
+    registry: &Registry,
+    task: TaskKind,
+) -> Result<(), OrchestratorError> {
+    let canon = registry
+        .canonical_for(task)
+        .ok_or(OrchestratorError::NoCanonical { task })?;
+    let (declared_id, declared_ver) = runner.model(task).ok_or(RunnerError::Unsupported(task))?;
+    if declared_id != canon.model_id || declared_ver != canon.canonical_version {
+        return Err(OrchestratorError::NonCanonicalRunner {
+            task,
+            declared: declared_id,
+        });
+    }
+    Ok(())
+}
+
+/// Embed `asset_id` under `task`'s canonical model and store the signed embedding derivative +
+/// index entry. Refuses a non-canonical runner.
+pub fn embed_and_store<R: ModelRunner>(
+    ws: &mut Workspace,
+    runner: &R,
+    registry: &Registry,
+    asset_id: &Uuid,
+    task: TaskKind,
+) -> Result<(), OrchestratorError> {
+    require_canonical_runner(runner, registry, task)?;
+    let bytes = ws.read_plaintext(asset_id)?;
+    let embedding = runner
+        .embed_image(task, &[Frame::new(&bytes)])?
+        .into_iter()
+        .next()
+        .ok_or_else(|| RunnerError::Inference("runner returned no embedding".into()))?;
+    ws.add_embedding_derivative(registry, asset_id, task, runner.platform(), &embedding)?;
+    Ok(())
+}
+
+/// Zero-shot tag `asset_id`: embed the image and each candidate label with the semantic-search
+/// embedder, then add as AI tags every label whose cosine similarity to the image clears
+/// `threshold`. Returns the labels assigned. No separate classifier — the semantic embeddings are
+/// reused (ai.md § Image Categorization & Tagging).
+pub fn auto_tag<R: ModelRunner>(
+    ws: &mut Workspace,
+    runner: &R,
+    registry: &Registry,
+    asset_id: &Uuid,
+    vocabulary: &[&str],
+    threshold: f32,
+) -> Result<Vec<String>, OrchestratorError> {
+    let task = TaskKind::SemanticSearch;
+    require_canonical_runner(runner, registry, task)?;
+    let canon = registry
+        .canonical_for(task)
+        .ok_or(OrchestratorError::NoCanonical { task })?;
+
+    let bytes = ws.read_plaintext(asset_id)?;
+    let image = runner
+        .embed_image(task, &[Frame::new(&bytes)])?
+        .into_iter()
+        .next()
+        .ok_or_else(|| RunnerError::Inference("runner returned no embedding".into()))?;
+    let label_vecs = runner.embed_text(vocabulary)?;
+
+    let mut assigned = Vec::new();
+    let mut ai_tags = Vec::new();
+    for (label, lv) in vocabulary.iter().zip(label_vecs) {
+        if cosine_sim(&image, &lv) >= threshold {
+            assigned.push((*label).to_string());
+            ai_tags.push(AiTag {
+                tag: (*label).to_string(),
+                model_id: canon.model_id.to_string(),
+                model_version: canon.canonical_version.to_string(),
+            });
+        }
+    }
+    if !ai_tags.is_empty() {
+        ws.add_ai_tags(asset_id, ai_tags)?;
+    }
+    Ok(assigned)
+}
+
+/// Natural-language search: embed `query` with the semantic-search embedder and return the `k`
+/// nearest assets in the runner's platform partition (current canonical version only).
+pub fn semantic_search<R: ModelRunner>(
+    ws: &Workspace,
+    runner: &R,
+    registry: &Registry,
+    query: &str,
+    k: usize,
+) -> Result<Vec<KnnHit>, OrchestratorError> {
+    require_canonical_runner(runner, registry, TaskKind::SemanticSearch)?;
+    let qv = runner
+        .embed_text(&[query])?
+        .into_iter()
+        .next()
+        .ok_or_else(|| RunnerError::Inference("runner returned no embedding".into()))?;
+    Ok(ws.db().knn(
+        registry,
+        TaskKind::SemanticSearch,
+        &qv,
+        k,
+        runner.platform(),
+    )?)
+}
+
+// ── Device-bound execution policy (ai.md § Model Batching) ───────────────────────────────────
+
+/// Per-asset execution mode, chosen from available memory at task start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatchMode {
+    /// One model resident at a time — minimizes peak VRAM at the cost of re-reading assets.
+    Horizontal,
+    /// All models resident per asset — minimizes I/O but risks OOM on mobile.
+    Vertical,
+}
+
+/// Pick the execution mode: go vertical only when the estimated resident set fits the RAM budget;
+/// otherwise stay horizontal to bound peak memory.
+pub fn choose_batch_mode(ram_budget_mb: u64, models_resident_mb: u64) -> BatchMode {
+    if models_resident_mb <= ram_budget_mb {
+        BatchMode::Vertical
+    } else {
+        BatchMode::Horizontal
+    }
+}
+
+/// The micro-batch sizes that keep the NPU cache hot.
+pub const MICRO_BATCH_SIZES: [usize; 3] = [8, 4, 1];
+
+/// The largest micro-batch size (from [`MICRO_BATCH_SIZES`]) that fits both the pending count and
+/// the device `ceiling`. Always at least 1.
+pub fn micro_batch_size(pending: usize, ceiling: usize) -> usize {
+    let cap = pending.min(ceiling);
+    MICRO_BATCH_SIZES
+        .into_iter()
+        .find(|&s| s <= cap)
+        .unwrap_or(1)
+}
+
+/// Whether to pause the pipeline for heat: at or above `threshold_c` the OS may kill the app, so
+/// the pipeline pauses until cooldown.
+pub fn should_pause_for_heat(temp_c: f32, threshold_c: f32) -> bool {
+    temp_c >= threshold_c
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_mode_follows_the_memory_budget() {
+        assert_eq!(choose_batch_mode(4096, 2048), BatchMode::Vertical);
+        assert_eq!(choose_batch_mode(1024, 2048), BatchMode::Horizontal);
+        assert_eq!(choose_batch_mode(2048, 2048), BatchMode::Vertical); // exactly fits
+    }
+
+    #[test]
+    fn micro_batch_clamps_to_ceiling_and_pending() {
+        assert_eq!(micro_batch_size(100, 8), 8);
+        assert_eq!(micro_batch_size(5, 8), 4);
+        assert_eq!(micro_batch_size(3, 8), 1);
+        assert_eq!(micro_batch_size(100, 4), 4);
+        assert_eq!(micro_batch_size(0, 8), 1); // never zero
+    }
+
+    #[test]
+    fn thermal_pause_triggers_at_threshold() {
+        assert!(!should_pause_for_heat(38.0, 40.0));
+        assert!(should_pause_for_heat(40.0, 40.0));
+        assert!(should_pause_for_heat(41.5, 40.0));
+    }
+
+    // ── Pipeline smoke tests (orchestrator × real Workspace × FixtureRunner) ─────────────────
+
+    use crate::crypto::primitives::Argon2Params;
+    use crate::ml::FixtureRunner;
+    use crate::ml::ModelVersion;
+    use tempfile::TempDir;
+
+    const PLATFORM: &str = "cpu-reference";
+
+    fn workspace_with(lib: &TempDir, src: &TempDir, bytes: &[u8]) -> (Workspace, Uuid) {
+        let img = src.path().join("p.jpg");
+        std::fs::write(&img, bytes).unwrap();
+        let mut ws = Workspace::create_with_params(
+            lib.path(),
+            b"pass",
+            Argon2Params {
+                mem_kib: 64,
+                t_cost: 1,
+                p_cost: 1,
+            },
+        )
+        .unwrap();
+        let album = ws.create_album("A");
+        let id = ws.import_asset(album, &img).unwrap();
+        (ws, id)
+    }
+
+    #[test]
+    fn embed_then_semantic_search_matches_the_indexed_asset() {
+        let (lib, src) = (TempDir::new().unwrap(), TempDir::new().unwrap());
+        let (mut ws, id) = workspace_with(&lib, &src, b"a beach at sunset");
+        let runner = FixtureRunner::new(PLATFORM);
+        let reg = Registry::canonical();
+
+        embed_and_store(&mut ws, &runner, &reg, &id, TaskKind::SemanticSearch).unwrap();
+
+        // The asset's content embeds identically to the matching query text → it is the top hit.
+        let hits = semantic_search(&ws, &runner, &reg, "a beach at sunset", 5).unwrap();
+        assert_eq!(hits[0].asset_id, id.to_string());
+        assert!(hits[0].distance < 1e-4);
+        // An unrelated query does not match it at distance ~0.
+        let other = semantic_search(&ws, &runner, &reg, "a city street", 5).unwrap();
+        assert!(other.iter().all(|h| h.distance > 1e-3));
+    }
+
+    #[test]
+    fn embed_and_store_refuses_a_non_canonical_runner() {
+        let (lib, src) = (TempDir::new().unwrap(), TempDir::new().unwrap());
+        let (mut ws, id) = workspace_with(&lib, &src, b"x");
+        // The runner declares model version 2, but the live registry's canonical is version 1.
+        let mut bumped = Registry::canonical();
+        bumped.set_canonical_version(TaskKind::SemanticSearch, ModelVersion::from("2"));
+        let runner = FixtureRunner::with_registry(PLATFORM, bumped);
+        let reg = Registry::canonical();
+
+        let err =
+            embed_and_store(&mut ws, &runner, &reg, &id, TaskKind::SemanticSearch).unwrap_err();
+        assert!(matches!(err, OrchestratorError::NonCanonicalRunner { .. }));
+        // Nothing was stored.
+        assert_eq!(
+            ws.db().embedding_count(TaskKind::SemanticSearch).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn auto_tag_assigns_matching_labels_as_ai_tags() {
+        let (lib, src) = (TempDir::new().unwrap(), TempDir::new().unwrap());
+        let (mut ws, id) = workspace_with(&lib, &src, b"beach");
+        let runner = FixtureRunner::new(PLATFORM);
+        let reg = Registry::canonical();
+
+        // The image content "beach" embeds identically to the "beach" label; others are unrelated.
+        let assigned =
+            auto_tag(&mut ws, &runner, &reg, &id, &["beach", "city", "dog"], 0.99).unwrap();
+        assert_eq!(assigned, vec!["beach".to_string()]);
+
+        // It landed in the AI namespace with the canonical provenance tuple — not in user tags.
+        let ai = ws.ai_tags(&id).unwrap();
+        assert_eq!(ai.len(), 1);
+        assert_eq!(ai[0].1.tag, "beach");
+        assert_eq!(ai[0].1.model_id, "mobileclip-b");
+        assert!(ws.db().tags_for(&id.to_string()).unwrap().is_empty());
+    }
+}

--- a/capsule-core/src/ml/reid.rs
+++ b/capsule-core/src/ml/reid.rs
@@ -1,0 +1,95 @@
+//! Re-identification & pseudo-labeling primitives (SSoT: [AI/ML — Re-ID & Pseudo-Labeling]).
+//!
+//! Identifies individuals even when they turn away from the camera: a high-confidence frontal
+//! face is matched to a profile, its box is linked to an overlapping body box (IoU > 0.7), and
+//! other body crops in the same event are pseudo-labeled by cosine similarity to that body
+//! embedding above a threshold. Pure geometry + vector math — detection/embedding come from a
+//! runner.
+//!
+//! [AI/ML — Re-ID & Pseudo-Labeling]: https://docs/design/ai/#re-id--pseudo-labeling
+
+use crate::ml::runner::BBox;
+
+/// The default IoU above which a face box and a body box are taken to be the same person.
+pub const DEFAULT_LINK_IOU: f32 = 0.7;
+
+/// Intersection-over-union of two normalized boxes (`0.0` if they do not overlap).
+pub fn iou(a: BBox, b: BBox) -> f32 {
+    let ax2 = a.x + a.w;
+    let ay2 = a.y + a.h;
+    let bx2 = b.x + b.w;
+    let by2 = b.y + b.h;
+    let iw = (ax2.min(bx2) - a.x.max(b.x)).max(0.0);
+    let ih = (ay2.min(by2) - a.y.max(b.y)).max(0.0);
+    let inter = iw * ih;
+    let union = a.w * a.h + b.w * b.h - inter;
+    if union <= 0.0 { 0.0 } else { inter / union }
+}
+
+/// Cosine similarity of two equal-length vectors (`0.0` if either is zero or lengths differ).
+pub fn cosine_sim(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        0.0
+    } else {
+        dot / (na * nb)
+    }
+}
+
+/// Whether a face box and a body box overlap enough to be linked as the same person
+/// (`iou > iou_threshold`). Pass [`DEFAULT_LINK_IOU`] for the design's 0.7.
+pub fn links_to_profile(face: BBox, body: BBox, iou_threshold: f32) -> bool {
+    iou(face, body) > iou_threshold
+}
+
+/// Whether a candidate body crop should inherit a profile's pseudo-label: its embedding's cosine
+/// similarity to the linked body embedding is at or above `sim_threshold`.
+pub fn pseudo_labels(anchor_body: &[f32], candidate_body: &[f32], sim_threshold: f32) -> bool {
+    cosine_sim(anchor_body, candidate_body) >= sim_threshold
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bbox(x: f32, y: f32, w: f32, h: f32) -> BBox {
+        BBox { x, y, w, h }
+    }
+
+    #[test]
+    fn iou_of_identical_boxes_is_one_and_disjoint_is_zero() {
+        let a = bbox(0.0, 0.0, 0.5, 0.5);
+        assert!((iou(a, a) - 1.0).abs() < 1e-6);
+        let b = bbox(0.6, 0.6, 0.2, 0.2);
+        assert_eq!(iou(a, b), 0.0);
+    }
+
+    #[test]
+    fn high_overlap_links_to_profile_low_does_not() {
+        let face = bbox(0.10, 0.10, 0.40, 0.40);
+        let body = bbox(0.11, 0.11, 0.40, 0.40); // ~94% IoU → linked
+        assert!(links_to_profile(face, body, DEFAULT_LINK_IOU));
+        let far = bbox(0.50, 0.50, 0.40, 0.40); // small overlap → not linked
+        assert!(!links_to_profile(face, far, DEFAULT_LINK_IOU));
+    }
+
+    #[test]
+    fn pseudo_label_above_threshold_only() {
+        let anchor = vec![1.0f32, 0.0, 0.0];
+        let same_dir = vec![2.0f32, 0.0, 0.0]; // cosine 1.0
+        let orthogonal = vec![0.0f32, 1.0, 0.0]; // cosine 0.0
+        assert!(pseudo_labels(&anchor, &same_dir, 0.8));
+        assert!(!pseudo_labels(&anchor, &orthogonal, 0.8));
+    }
+
+    #[test]
+    fn cosine_sim_handles_degenerate_inputs() {
+        assert_eq!(cosine_sim(&[1.0, 2.0], &[1.0]), 0.0); // length mismatch
+        assert_eq!(cosine_sim(&[0.0, 0.0], &[1.0, 1.0]), 0.0); // zero vector
+    }
+}

--- a/capsule-core/src/ml/runner.rs
+++ b/capsule-core/src/ml/runner.rs
@@ -1,0 +1,289 @@
+//! The inference seam — a [`ModelRunner`] trait the orchestrator consumes, plus a deterministic
+//! [`FixtureRunner`] for tests (SSoT: [AI/ML Integrations]).
+//!
+//! Real per-platform runners (ONNX Runtime / CoreML / NNAPI, behind a default-off, weight-fetching
+//! feature) implement this trait. Until then `FixtureRunner` stands in — exactly as
+//! [`ReferenceAuthority`](crate::crypto::authority::ReferenceAuthority) stands in for live MLS
+//! behind [`AlbumAuthority`](crate::crypto::authority::AlbumAuthority). The fixture maps an input's
+//! bytes to a reproducible L2-normalized vector by expanding SHA-256, so identical content embeds
+//! identically and semantic matches are testable without any model weights.
+//!
+//! [AI/ML Integrations]: https://docs/design/ai/
+
+use thiserror::Error;
+
+use crate::crypto::hash;
+use crate::ml::{ModelId, ModelVersion, Registry, TaskKind};
+
+/// An embedding vector (L2-normalized by convention, so cosine ranks like the inner product).
+pub type Embedding = Vec<f32>;
+
+/// One image (or video keyframe) handed to a runner. The offline core passes the asset's bytes; a
+/// real runner decodes + runs the model, the fixture hashes them.
+#[derive(Debug, Clone, Copy)]
+pub struct Frame<'a> {
+    /// The image bytes.
+    pub bytes: &'a [u8],
+}
+
+impl<'a> Frame<'a> {
+    /// A frame over `bytes`.
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes }
+    }
+}
+
+/// A normalized bounding box (coordinates in `[0, 1]`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BBox {
+    /// Left.
+    pub x: f32,
+    /// Top.
+    pub y: f32,
+    /// Width.
+    pub w: f32,
+    /// Height.
+    pub h: f32,
+}
+
+/// A detection from a detection task (object box, face box + landmarks downstream).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Detection {
+    /// Where.
+    pub bbox: BBox,
+    /// Optional class label.
+    pub label: Option<String>,
+    /// Confidence in `[0, 1]`.
+    pub score: f32,
+}
+
+/// Errors a runner can return.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RunnerError {
+    /// The runner cannot serve this task (e.g. an embedding call on a detection task).
+    #[error("runner does not support task {0:?}")]
+    Unsupported(TaskKind),
+    /// Inference failed.
+    #[error("inference failed: {0}")]
+    Inference(String),
+}
+
+/// The inference seam every consumer routes through. Implemented by real per-platform runners and
+/// by [`FixtureRunner`] for tests.
+pub trait ModelRunner {
+    /// The platform partition tag for this runner's outputs (incomparable across platforms).
+    fn platform(&self) -> &str;
+
+    /// The `(model_id, model_version)` this runner produces for `task`, if it serves it. Must equal
+    /// the registry's canonical row for the output to be accepted by the index.
+    fn model(&self, task: TaskKind) -> Option<(ModelId, ModelVersion)>;
+
+    /// Embed images for an embedding task (`SemanticSearch`, `FaceRecognition`). One vector per
+    /// frame, in order.
+    fn embed_image(
+        &self,
+        task: TaskKind,
+        frames: &[Frame<'_>],
+    ) -> Result<Vec<Embedding>, RunnerError>;
+
+    /// Embed text into the semantic-search space — for natural-language queries and the zero-shot
+    /// tagging that reuses the semantic embedder.
+    fn embed_text(&self, texts: &[&str]) -> Result<Vec<Embedding>, RunnerError>;
+
+    /// Detect objects / faces for a detection task (`ObjectDetection`, `FaceDetection`). One list
+    /// per frame, in order.
+    fn detect(
+        &self,
+        task: TaskKind,
+        frames: &[Frame<'_>],
+    ) -> Result<Vec<Vec<Detection>>, RunnerError>;
+}
+
+/// Expand SHA-256 of `bytes` into a deterministic, L2-normalized `dim`-vector. Identical bytes
+/// produce an identical vector; distinct bytes produce near-orthogonal vectors.
+fn deterministic_embedding(bytes: &[u8], dim: usize) -> Embedding {
+    let mut out: Embedding = Vec::with_capacity(dim);
+    let mut counter: u32 = 0;
+    while out.len() < dim {
+        let mut input = bytes.to_vec();
+        input.extend_from_slice(&counter.to_le_bytes());
+        let digest = hash::hash_bytes(&input);
+        for pair in digest.0.chunks_exact(2) {
+            if out.len() == dim {
+                break;
+            }
+            // Map two bytes to roughly [-1, 1).
+            let v = i16::from_le_bytes([pair[0], pair[1]]) as f32 / 32768.0;
+            out.push(v);
+        }
+        counter += 1;
+    }
+    l2_normalize(&mut out);
+    out
+}
+
+fn l2_normalize(v: &mut [f32]) {
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in v.iter_mut() {
+            *x /= norm;
+        }
+    }
+}
+
+/// A deterministic, weightless runner for tests. Declares the canonical model versions from a
+/// [`Registry`] (so its outputs satisfy the embedding-provenance invariant) and embeds by hashing
+/// input bytes — content equality ⇒ vector equality, which makes semantic matches reproducible.
+#[derive(Debug, Clone)]
+pub struct FixtureRunner {
+    platform: String,
+    registry: Registry,
+}
+
+impl FixtureRunner {
+    /// A fixture on `platform` declaring the canonical inventory's model versions.
+    pub fn new(platform: &str) -> Self {
+        Self {
+            platform: platform.to_string(),
+            registry: Registry::canonical(),
+        }
+    }
+
+    /// A fixture whose declared model versions come from `registry` — for simulating a model swap
+    /// (a runner that produces the *new* canonical version after a bump).
+    pub fn with_registry(platform: &str, registry: Registry) -> Self {
+        Self {
+            platform: platform.to_string(),
+            registry,
+        }
+    }
+
+    fn dim(&self, task: TaskKind) -> Result<usize, RunnerError> {
+        self.registry
+            .dim_for(task)
+            .map(|d| d.get())
+            .ok_or(RunnerError::Unsupported(task))
+    }
+}
+
+impl ModelRunner for FixtureRunner {
+    fn platform(&self) -> &str {
+        &self.platform
+    }
+
+    fn model(&self, task: TaskKind) -> Option<(ModelId, ModelVersion)> {
+        self.registry
+            .canonical_for(task)
+            .map(|r| (r.model_id.clone(), r.canonical_version.clone()))
+    }
+
+    fn embed_image(
+        &self,
+        task: TaskKind,
+        frames: &[Frame<'_>],
+    ) -> Result<Vec<Embedding>, RunnerError> {
+        let dim = self.dim(task)?;
+        Ok(frames
+            .iter()
+            .map(|f| deterministic_embedding(f.bytes, dim))
+            .collect())
+    }
+
+    fn embed_text(&self, texts: &[&str]) -> Result<Vec<Embedding>, RunnerError> {
+        // Text shares the semantic-search space.
+        let dim = self.dim(TaskKind::SemanticSearch)?;
+        Ok(texts
+            .iter()
+            .map(|t| deterministic_embedding(t.as_bytes(), dim))
+            .collect())
+    }
+
+    fn detect(
+        &self,
+        task: TaskKind,
+        frames: &[Frame<'_>],
+    ) -> Result<Vec<Vec<Detection>>, RunnerError> {
+        match task {
+            TaskKind::ObjectDetection | TaskKind::FaceDetection => {
+                // The fixture has no real detector; it reports no detections deterministically.
+                Ok(frames.iter().map(|_| Vec::new()).collect())
+            }
+            other => Err(RunnerError::Unsupported(other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_embeddings_are_deterministic_and_normalized() {
+        let r = FixtureRunner::new("cpu-reference");
+        let a = r
+            .embed_image(TaskKind::SemanticSearch, &[Frame::new(b"beach")])
+            .unwrap();
+        let b = r
+            .embed_image(TaskKind::SemanticSearch, &[Frame::new(b"beach")])
+            .unwrap();
+        assert_eq!(a, b, "same bytes ⇒ same vector");
+        assert_eq!(a[0].len(), 512);
+        let norm = a[0].iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-4, "L2-normalized");
+    }
+
+    #[test]
+    fn identical_image_and_text_content_embed_identically() {
+        // The property that makes semantic-match tests possible without real inference.
+        let r = FixtureRunner::new("cpu-reference");
+        let img = r
+            .embed_image(
+                TaskKind::SemanticSearch,
+                &[Frame::new(b"a beach at sunset")],
+            )
+            .unwrap();
+        let txt = r.embed_text(&["a beach at sunset"]).unwrap();
+        assert_eq!(img[0], txt[0]);
+        // A different concept embeds differently.
+        let other = r.embed_text(&["a city street"]).unwrap();
+        assert_ne!(img[0], other[0]);
+    }
+
+    #[test]
+    fn fixture_declares_canonical_models() {
+        let r = FixtureRunner::new("cpu-reference");
+        assert_eq!(
+            r.model(TaskKind::SemanticSearch),
+            Some((ModelId::from("mobileclip-b"), ModelVersion::from("1")))
+        );
+        assert_eq!(
+            r.model(TaskKind::FaceDetection),
+            Some((ModelId::from("scrfd"), ModelVersion::from("1")))
+        );
+    }
+
+    #[test]
+    fn embedding_a_detection_task_is_unsupported() {
+        let r = FixtureRunner::new("cpu-reference");
+        assert_eq!(
+            r.embed_image(TaskKind::ObjectDetection, &[Frame::new(b"x")]),
+            Err(RunnerError::Unsupported(TaskKind::ObjectDetection))
+        );
+        // ...but detection on a detection task is fine (empty, deterministically).
+        assert_eq!(
+            r.detect(TaskKind::ObjectDetection, &[Frame::new(b"x")]),
+            Ok(vec![vec![]])
+        );
+    }
+
+    #[test]
+    fn a_bumped_registry_makes_the_fixture_declare_the_new_version() {
+        let mut reg = Registry::canonical();
+        reg.set_canonical_version(TaskKind::SemanticSearch, ModelVersion::from("2"));
+        let r = FixtureRunner::with_registry("cpu-reference", reg);
+        assert_eq!(
+            r.model(TaskKind::SemanticSearch),
+            Some((ModelId::from("mobileclip-b"), ModelVersion::from("2")))
+        );
+    }
+}

--- a/capsule-core/src/ml/video.rs
+++ b/capsule-core/src/ml/video.rs
@@ -1,0 +1,98 @@
+//! Video-as-sparse-photos keyframe selection (SSoT: [AI/ML — Video-as-Sparse-Photos]).
+//!
+//! Processing every frame through heavy models is prohibitive, so a video is treated as a sparse
+//! set of keyframes: content-aware cut detection chunks it into scenes (provided here as input),
+//! each scene is sampled at the 10% / 50% / 90% timestamps, and frames too blurry (low Laplacian
+//! variance) are rejected before they enter the image queue. Pure functions over timing + blur
+//! metrics — the heavy decode/cut-detect lives in a runner.
+//!
+//! [AI/ML — Video-as-Sparse-Photos]: https://docs/design/ai/#video-as-sparse-photos
+
+/// A content-aware scene as a `[start_ms, end_ms)` range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Scene {
+    /// Scene start (ms from the video start).
+    pub start_ms: u64,
+    /// Scene end (exclusive).
+    pub end_ms: u64,
+}
+
+/// A sampled keyframe — its timestamp in the parent video.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Keyframe {
+    /// Timestamp (ms) of the sampled frame in the parent video.
+    pub timestamp_ms: u64,
+}
+
+/// The temporal sample points within each scene (percent of the scene duration).
+pub const SAMPLE_FRACTIONS_PERCENT: [u64; 3] = [10, 50, 90];
+
+/// Sample keyframes at the 10% / 50% / 90% timestamps of each scene.
+pub fn sample_keyframes(scenes: &[Scene]) -> Vec<Keyframe> {
+    let mut out = Vec::with_capacity(scenes.len() * SAMPLE_FRACTIONS_PERCENT.len());
+    for s in scenes {
+        let dur = s.end_ms.saturating_sub(s.start_ms);
+        for frac in SAMPLE_FRACTIONS_PERCENT {
+            out.push(Keyframe {
+                timestamp_ms: s.start_ms + dur * frac / 100,
+            });
+        }
+    }
+    out
+}
+
+/// Whether a frame is sharp enough to keep: the variance of its Laplacian is at or above
+/// `threshold`. Below it, the frame is discarded as too blurry.
+pub fn is_sharp(laplacian_variance: f64, threshold: f64) -> bool {
+    laplacian_variance >= threshold
+}
+
+/// Keep only the keyframes whose Laplacian variance clears `threshold`.
+pub fn reject_blurry(frames: Vec<(Keyframe, f64)>, threshold: f64) -> Vec<Keyframe> {
+    frames
+        .into_iter()
+        .filter(|(_, var)| is_sharp(*var, threshold))
+        .map(|(kf, _)| kf)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn samples_at_ten_fifty_ninety_percent_of_each_scene() {
+        let scenes = [
+            Scene {
+                start_ms: 0,
+                end_ms: 1000,
+            },
+            Scene {
+                start_ms: 2000,
+                end_ms: 2500,
+            },
+        ];
+        let kf = sample_keyframes(&scenes);
+        let ts: Vec<u64> = kf.iter().map(|k| k.timestamp_ms).collect();
+        assert_eq!(ts, vec![100, 500, 900, 2050, 2250, 2450]);
+    }
+
+    #[test]
+    fn empty_input_yields_no_keyframes() {
+        assert!(sample_keyframes(&[]).is_empty());
+    }
+
+    #[test]
+    fn blur_rejection_drops_frames_below_threshold() {
+        let frames = vec![
+            (Keyframe { timestamp_ms: 100 }, 5.0),   // blurry
+            (Keyframe { timestamp_ms: 500 }, 150.0), // sharp
+            (Keyframe { timestamp_ms: 900 }, 99.9),  // just below
+        ];
+        let kept = reject_blurry(frames, 100.0);
+        assert_eq!(
+            kept.iter().map(|k| k.timestamp_ms).collect::<Vec<_>>(),
+            vec![500]
+        );
+    }
+}


### PR DESCRIPTION
## What

Fifth PR in the **on-device ML stack** (stacked on #339). Adds the `capsule-core::ml` orchestration layer — the inference seam, the pipeline that ties a runner to the signed lifecycle, and the standalone algorithms `ai.md` specifies.

### The seam (`ml::runner`)
- **`ModelRunner` trait** — `embed_image` / `embed_text` / `detect` / `model(task)` / `platform()`. Real per-platform runners (ONNX/CoreML/NNAPI, default-off weight-fetching feature) implement it.
- **`FixtureRunner`** — deterministic, weightless. Expands SHA-256 into L2-normalized vectors, so identical content embeds identically — semantic matches are testable with **no model weights**. Mirrors `ReferenceAuthority` standing in for live MLS behind `AlbumAuthority`.

### Orchestration (`ml::orchestrator`)
- **`embed_and_store`** — run the canonical model over an asset → signed embedding derivative (#339) + index entry (#336). **Refuses a non-canonical runner** (embedding-provenance invariant enforced at the boundary).
- **`auto_tag`** — zero-shot tagging by *reusing* the semantic embeddings (image-vs-label cosine over a threshold) → AI tags (#338); no separate classifier, per `ai.md`.
- **`semantic_search`** — natural-language query → KNN in the current `(platform, version)` partition.
- **Device policy** — `choose_batch_mode` (horizontal/vertical by RAM), `micro_batch_size` (1/4/8 ceiling), `should_pause_for_heat` (thermal throttle).

### Algorithms
- **`ml::video`** — video-as-sparse-photos: keyframe sampling at 10/50/90% per scene + Laplacian-variance blur rejection.
- **`ml::reid`** — IoU, cosine similarity, face↔body linking (IoU > 0.7), cosine-threshold pseudo-labeling.

## Design conformance (`ai.md`)

Maps to *Semantic Indexing*, *Image Categorization & Tagging* (zero-shot reuse), *Model Batching*, *Video-as-Sparse-Photos*, *Re-ID & Pseudo-Labeling*, and the *Algorithm correctness* / *Thermal throttle / batching bound* validation bullets. Per-platform bit-exact inference parity stays deferred (needs real runners + field testing).

## Testing

18 tests: fixture determinism + content-equality embedding + canonical declaration; batching/micro-batch/thermal policy; keyframe timestamps + blur rejection; IoU/cosine/linking/pseudo-label; and orchestrator smoke (embed→semantic-search match, non-canonical runner refused, zero-shot auto_tag lands in the AI namespace). Full `cargo test -p capsule-core` → **323 passed**. `clippy --workspace --exclude capsule-sdk -D warnings` + `fmt --check` clean.

## Stack
#335 ← #336 ← #338 ← #339 ← **this** ← regeneration + bounded E2E + demo.