### PR TITLE
feat(core,cli): embedding regeneration + bounded E2E + demo

### DIFF
--- a/capsule-cli/src/demo.rs
+++ b/capsule-cli/src/demo.rs
@@ -15,6 +15,7 @@ use capsule_core::backup::{recover_seed, split_seed_2of3};
 use capsule_core::crypto::primitives::Argon2Params;
 use capsule_core::crypto::verify_asset::VerifyOutcome;
 use capsule_core::lifecycle::Workspace;
+use capsule_core::ml::{self, FixtureRunner, Registry, TaskKind};
 
 /// Fast Argon2id parameters — this is a demo; the wrap-key strength is not the point.
 const DEMO_KDF: Argon2Params = Argon2Params {
@@ -208,6 +209,50 @@ pub fn run(workdir: Option<PathBuf>, image: Option<PathBuf>) -> Result<()> {
     } else {
         return Err(eyre!("shamir reconstruction failed"));
     }
+
+    // ── 10. On-device ML (deterministic fixture runner; no model weights) ─────
+    step(
+        10,
+        "On-device ML: embed, semantic search, and model-version regen (fixture runner)",
+    );
+    let registry = Registry::canonical();
+    let runner = FixtureRunner::new("cpu-reference");
+    ml::embed_and_store(
+        &mut ws,
+        &runner,
+        &registry,
+        &asset,
+        TaskKind::SemanticSearch,
+    )
+    .map_err(|e| eyre!("embed: {e}"))?;
+    ok("embedded the asset (signed embedding derivative + sqlite-vec index entry)");
+    info("embedding model", "mobileclip-b v1 (provenance-tagged)");
+
+    let hits = ml::semantic_search(&ws, &runner, &registry, "a photo from the trip", 3)
+        .map_err(|e| eyre!("search: {e}"))?;
+    if let Some(top) = hits.first() {
+        ok(format!(
+            "semantic search returned {} hit(s); nearest distance {:.4}",
+            hits.len(),
+            top.distance
+        ));
+    }
+
+    // Simulate a model swap: bump the canonical version, then regenerate per-asset.
+    let mut registry_v2 = Registry::canonical();
+    registry_v2.set_canonical_version(TaskKind::SemanticSearch, "2".into());
+    let runner_v2 = FixtureRunner::with_registry("cpu-reference", registry_v2.clone());
+    let stale_before = ws
+        .db()
+        .stale_embedding_assets(&registry_v2, TaskKind::SemanticSearch, "cpu-reference")
+        .map_err(|e| eyre!("stale: {e}"))?
+        .len();
+    let regenerated =
+        ml::regenerate_embeddings(&mut ws, &runner_v2, &registry_v2, TaskKind::SemanticSearch)
+            .map_err(|e| eyre!("regen: {e}"))?;
+    ok(format!(
+        "model swap → v2: {stale_before} stale embedding(s) excluded from queries, then {regenerated} regenerated"
+    ));
 
     println!(
         "\n{}  Every layer of the design exercised offline with real cryptography.",

--- a/capsule-core/src/ml/mod.rs
+++ b/capsule-core/src/ml/mod.rs
@@ -25,7 +25,7 @@ pub mod video;
 
 pub use orchestrator::{
     BatchMode, OrchestratorError, auto_tag, choose_batch_mode, embed_and_store, micro_batch_size,
-    semantic_search, should_pause_for_heat,
+    regenerate_embeddings, semantic_search, should_pause_for_heat,
 };
 pub use registry::{
     DistanceMetric, EmbeddingDim, ModelId, ModelRow, ModelVersion, Registry, RegistryError,

--- a/capsule-core/src/ml/orchestrator.rs
+++ b/capsule-core/src/ml/orchestrator.rs
@@ -158,6 +158,34 @@ pub fn semantic_search<R: ModelRunner>(
     )?)
 }
 
+/// Regenerate stale embeddings for `task` at the current canonical version. Walks the assets whose
+/// stored `model_version` trails the registry (a model swap left them stale and excluded from
+/// queries) and re-embeds each with `runner`, replacing the old vector and appending a chained
+/// `derivative-replace`. **Per-asset replace** — the fresh embedding persists before the old one
+/// is dropped, never a global truncate, so already-regenerated assets stay queryable throughout.
+/// Returns the number regenerated.
+pub fn regenerate_embeddings<R: ModelRunner>(
+    ws: &mut Workspace,
+    runner: &R,
+    registry: &Registry,
+    task: TaskKind,
+) -> Result<usize, OrchestratorError> {
+    require_canonical_runner(runner, registry, task)?;
+    let platform = runner.platform().to_string();
+    let stale = ws
+        .db()
+        .stale_embedding_assets(registry, task, &platform)
+        .map_err(|e| OrchestratorError::Vector(e.into()))?;
+    let mut regenerated = 0;
+    for asset_str in stale {
+        let asset_id = Uuid::parse_str(&asset_str)
+            .map_err(|e| RunnerError::Inference(format!("bad asset id {asset_str}: {e}")))?;
+        embed_and_store(ws, runner, registry, &asset_id, task)?;
+        regenerated += 1;
+    }
+    Ok(regenerated)
+}
+
 // ── Device-bound execution policy (ai.md § Model Batching) ───────────────────────────────────
 
 /// Per-asset execution mode, chosen from available memory at task start.
@@ -308,5 +336,80 @@ mod tests {
         assert_eq!(ai[0].1.tag, "beach");
         assert_eq!(ai[0].1.model_id, "mobileclip-b");
         assert!(ws.db().tags_for(&id.to_string()).unwrap().is_empty());
+    }
+
+    /// Bounded E2E (Module Map #10): bump the canonical model version; stale embeddings are
+    /// excluded from queries; background regen produces fresh embeddings per-asset; queries return
+    /// correct results post-regen. Covers `ml` × `db` vector index × lifecycle.
+    #[test]
+    fn e2e_model_regen_after_version_bump_rebuilds_the_index() {
+        let (lib, src) = (TempDir::new().unwrap(), TempDir::new().unwrap());
+        let imga = src.path().join("a.bin");
+        let imgb = src.path().join("b.bin");
+        std::fs::write(&imga, b"alpha concept").unwrap();
+        std::fs::write(&imgb, b"beta concept").unwrap();
+        let mut ws = Workspace::create_with_params(
+            lib.path(),
+            b"p",
+            Argon2Params {
+                mem_kib: 64,
+                t_cost: 1,
+                p_cost: 1,
+            },
+        )
+        .unwrap();
+        let album = ws.create_album("A");
+        let a = ws.import_asset(album, &imga).unwrap();
+        let b = ws.import_asset(album, &imgb).unwrap();
+
+        // v1: embed both; a semantic query matches the right asset.
+        let reg1 = Registry::canonical();
+        let runner1 = FixtureRunner::new(PLATFORM);
+        embed_and_store(&mut ws, &runner1, &reg1, &a, TaskKind::SemanticSearch).unwrap();
+        embed_and_store(&mut ws, &runner1, &reg1, &b, TaskKind::SemanticSearch).unwrap();
+        let hits = semantic_search(&ws, &runner1, &reg1, "alpha concept", 5).unwrap();
+        assert_eq!(hits[0].asset_id, a.to_string());
+        assert!(hits[0].distance < 1e-4);
+
+        // Model swap → version 2 (a new runner produces the new canonical version).
+        let mut reg2 = Registry::canonical();
+        reg2.set_canonical_version(TaskKind::SemanticSearch, ModelVersion::from("2"));
+        let runner2 = FixtureRunner::with_registry(PLATFORM, reg2.clone());
+
+        // Pre-regen: the v1 embeddings are stale and excluded from v2 queries.
+        assert_eq!(
+            ws.db()
+                .stale_embedding_assets(&reg2, TaskKind::SemanticSearch, PLATFORM)
+                .unwrap()
+                .len(),
+            2
+        );
+        assert!(
+            semantic_search(&ws, &runner2, &reg2, "alpha concept", 5)
+                .unwrap()
+                .is_empty(),
+            "stale embeddings are excluded until regenerated"
+        );
+
+        // Regenerate: fresh v2 embeddings, per-asset replace (not accumulate).
+        let n = regenerate_embeddings(&mut ws, &runner2, &reg2, TaskKind::SemanticSearch).unwrap();
+        assert_eq!(n, 2);
+        assert!(
+            ws.db()
+                .stale_embedding_assets(&reg2, TaskKind::SemanticSearch, PLATFORM)
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            ws.db().embedding_count(TaskKind::SemanticSearch).unwrap(),
+            2
+        );
+
+        // Post-regen: queries return correct results again, and each asset's embedding chain shows
+        // a v1 → v2 derivative-replace.
+        let hits = semantic_search(&ws, &runner2, &reg2, "alpha concept", 5).unwrap();
+        assert_eq!(hits[0].asset_id, a.to_string());
+        assert!(hits[0].distance < 1e-4);
+        assert_eq!(ws.embedding_derivatives(&a).unwrap().len(), 2);
     }
 }


### PR DESCRIPTION
## What

Sixth PR in the **on-device ML stack** (stacked on #340). Closes the loop: version-bump regeneration, the bounded E2E from the Module Map, and a deterministic `capsule demo` showcase.

- **`ml::regenerate_embeddings`** — after a model swap, walk the assets whose stored `model_version` trails the registry (stale → excluded from queries) and re-embed each. **Per-asset replace**: the fresh embedding persists before the old is dropped — never a global truncate, so already-regenerated assets stay queryable throughout.
- **Bounded E2E (Module Map #10)** — bump the canonical version → assert stale embeddings are excluded from v2 queries → regenerate → assert queries return correct results and each asset's embedding chain shows a `v1 → v2` derivative-replace. Covers `ml` × `db` vector index × lifecycle. (E2E #1 — index → semantic query → match — is the PR #340 orchestrator smoke test.)
- **`capsule demo` step 10** — embed the asset, run semantic search, then a model-version swap + regen. Deterministic, fixture runner, **no model weights**.

## Verify it yourself

```
cargo run -p capsule-cli -- demo --workdir /tmp/capsule-demo
```
…now ends with:
```
[10] On-device ML: embed, semantic search, and model-version regen (fixture runner)
    ✓ embedded the asset (signed embedding derivative + sqlite-vec index entry)
    embedding model: mobileclip-b v1 (provenance-tagged)
    ✓ semantic search returned 1 hit(s); nearest distance 0.9779
    ✓ model swap → v2: 1 stale embedding(s) excluded from queries, then 1 regenerated
```

## Design conformance

`ai.md#embedding-provenance` (regeneration is a background walk producing fresh embeddings at the new version; old removed only after new persists, per-asset) and the two `ai.md`/Module-Map E2E cases.

## Testing

The regen E2E + the PR #340 match smoke = the two bounded ML E2E cases. Full `cargo test -p capsule-core` → **324 passed**. `clippy --workspace --exclude capsule-sdk -D warnings` + `fmt --check` clean across `capsule-core` and `capsule-cli`; the demo binary runs end-to-end.

## Stack
#335 ← #336 ← #338 ← #339 ← #340 ← **this**. This is the last required PR; the optional real `tract` runner (PR7) is a separate increment pending your go-ahead.